### PR TITLE
訊息閱讀器功能改進與 bug 修正

### DIFF
--- a/addon/appModules/_chatParser.py
+++ b/addon/appModules/_chatParser.py
@@ -2,7 +2,7 @@ import re
 
 _DATE_RE = re.compile(r'^\d{4}\.\d{2}\.\d{2} .+$')
 _MSG_RE = re.compile(r'^(\d{2}:\d{2}) (\S+?) (.+)$')
-_RECALL_RE = re.compile(r'^(\d{2}:\d{2}) (\S+?)已收回訊息$')
+_RECALL_RE = re.compile(r'^(\d{2}:\d{2}) (\S+?) 已收回訊息$')
 
 
 def parseChatFile(filePath):

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -5986,7 +5986,7 @@ class AppModule(appModuleHandler.AppModule):
 		# The file dialog has a ComboBoxEx32 > ComboBox > Edit hierarchy
 		editHwnd = self._findSaveDialogEdit(dialogHwnd)
 		if not editHwnd:
-    self._messageReaderPending = False
+			self._messageReaderPending = False
 			ui.message(_("無法操作儲存對話框"))
 			return
 

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -5941,7 +5941,6 @@ class AppModule(appModuleHandler.AppModule):
 		"""Find the Save As dialog, set filename to temp folder, and save."""
 		import ctypes
 		import ctypes.wintypes as wintypes
-		import tempfile
 
 		lineProcessId = self.processID
 		WNDENUMPROC = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)


### PR DESCRIPTION
## Summary

- 修正 `_messageReaderHandleSaveDialog` 的縮排錯誤（line 5989）
- 修正 `_RECALL_RE` 正則表達式缺少空格（與 `_MSG_RE` 格式一致）
- 移除 `_messageReaderHandleSaveDialog` 函式開頭重複的 `import tempfile`

## Changes

1. **縮排修正**：`self._messageReaderPending = False` 使用正確的 tab 縮排
2. **正則表達式修正**：`_RECALL_RE` 姓名捕獲組後補上空格，使其與標準訊息格式相符
3. **移除冗余導入**：刪除函式開頭的重複 `import tempfile`，保留後續使用的那個

## Testing

已透過 NVDA 測試驗證訊息閱讀器功能正常運作。

🤖 Generated by Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 修正了訊息閱讀器功能中三個問題：縮排錯誤、正規表達式格式不一致，以及函式中重複的 `import tempfile` 宣告。

- **縮排修正**：`_messageReaderHandleSaveDialog` 中，`self._messageReaderPending = False`（line 5988）現在正確地在 `if not editHwnd:` 區塊內，確保只有在找不到編輯控制項時才會重設狀態，避免了狀態被錯誤清除的 bug。
- **正規表達式修正**：`_RECALL_RE` 於 `(\\S+?)` 後補上空格，使其與 `_MSG_RE` 格式一致，確保「已收回訊息」格式能被正確匹配。
- **移除重複 import**：刪除 `_messageReaderHandleSaveDialog` 函式開頭重複的 `import tempfile`，保留函式中實際使用的那個。

<h3>Confidence Score: 5/5</h3>

此 PR 僅包含三個小範圍的 bug 修正，邏輯清晰，可安全合併。

三項修正（縮排、正規表達式、重複 import）皆有明確的問題與對應修正，且範圍小、風險低。修正後的程式碼邏輯正確，與周圍程式碼一致。

無需特別關注的檔案。

<details open><summary><h3>Vulnerabilities</h3></summary>

未發現安全疑慮。
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/_chatParser.py | 補上 `_RECALL_RE` 中 `(\S+?)` 後缺少的空格，使其與 `_MSG_RE` 格式一致，確保「已收回訊息」行能被正確解析。 |
| addon/appModules/line.py | 修正 `_messageReaderHandleSaveDialog` 中 `self._messageReaderPending = False` 的縮排，使其正確位於 `if not editHwnd:` 區塊內；並移除函式開頭重複的 `import tempfile`。 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_messageReaderHandleSaveDialog 呼叫] --> B{找到 Save As 對話框?}
    B -- 否, retriesLeft > 0 --> C[callLater 300ms 重試]
    B -- 否, retriesLeft == 0 --> D[_messageReaderPending = False\n顯示錯誤訊息]
    D --> E[return]
    C --> A
    B -- 是 --> F[建立暫存檔路徑\nimport tempfile]
    F --> G[預先刪除既有檔案]
    G --> H[_findSaveDialogEdit]
    H --> I{找到 Edit 控制項?}
    I -- 否 --> J[_messageReaderPending = False\n縮排修正\n顯示錯誤訊息]
    J --> K[return]
    I -- 是 --> L[SendMessageW 設定檔名]
    L --> M[callLater 200ms\n_messageReaderPressSave]
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;claude/gracious-wright&#39; of..."](https://github.com/keyang556/linedesktopnvda/commit/687f361ab1bf850fe20fc8662e11cabd1ce732c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27815602)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->