### PR TITLE
Revert "訊息閱讀器功能改進與 bug 修正"

### DIFF
--- a/addon/appModules/_chatParser.py
+++ b/addon/appModules/_chatParser.py
@@ -2,7 +2,7 @@ import re
 
 _DATE_RE = re.compile(r'^\d{4}\.\d{2}\.\d{2} .+$')
 _MSG_RE = re.compile(r'^(\d{2}:\d{2}) (\S+?) (.+)$')
-_RECALL_RE = re.compile(r'^(\d{2}:\d{2}) (\S+?) 已收回訊息$')
+_RECALL_RE = re.compile(r'^(\d{2}:\d{2}) (\S+?)已收回訊息$')
 
 
 def parseChatFile(filePath):

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -5941,6 +5941,7 @@ class AppModule(appModuleHandler.AppModule):
 		"""Find the Save As dialog, set filename to temp folder, and save."""
 		import ctypes
 		import ctypes.wintypes as wintypes
+		import tempfile
 
 		lineProcessId = self.processID
 		WNDENUMPROC = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)


### PR DESCRIPTION
Reverts keyang556/linedesktopnvda#48

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 將 PR #48（「訊息閱讀器功能改進與 bug 修正」）的所有變更還原，將 `addon/appModules/_chatParser.py` 與 `addon/appModules/line.py` 恢復到 PR #47 合併後的狀態。

- 還原為乾淨且完整：僅 `_chatParser.py` 與 `line.py` 兩個檔案被 PR #48 修改過，此 PR 將這兩者均完整還原；`_messageReader.py`、`_utils.py`、`_virtualWindow.py`、`linecall.py` 均未受影響。
- PR 描述僅說明「還原 PR #48」，但未說明還原的原因（例如 PR #48 引入了新的問題）。建議在描述中補充說明為何需要還原。
- `_messageReaderHandleSaveDialog` 中存在重複的 `import tempfile`（第 5944 行與第 5974 行），為 PR #47 狀態就已存在的輕微程式碼品質問題，此次 PR 並未引入。

<h3>Confidence Score: 4/5</h3>

此 PR 為乾淨且完整的還原，可安全合併，但未說明還原原因。

還原操作正確且完整：PR #48 所修改的兩個檔案（_chatParser.py、line.py）均被還原至 PR #47 合併後的狀態，其餘檔案（_messageReader.py 等）未受影響且介面相容。唯一的顧慮是 PR 描述未說明還原的原因，令人難以判斷 PR #48 的改進是否因新 bug 而需放棄。

無需特別關注的檔案，但建議補充說明還原 PR #48 的原因。

<details open><summary><h3>Vulnerabilities</h3></summary>

未發現安全性問題。聊天紀錄檔案儲存路徑使用系統暫存目錄（`tempfile.gettempdir()`），並在讀取前先確認檔案存在，整體處理方式合理安全。
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| addon/appModules/_chatParser.py | 還原至 PR #47 狀態的聊天紀錄解析器，包含多行訊息支援與已修正的 _RECALL_RE 空格問題；邏輯正確。 |
| addon/appModules/line.py | 還原至 PR #47 狀態的主模組，訊息閱讀器流程（開啟、儲存、解析、呈現）結構完整；_messageReaderHandleSaveDialog 中有重複的 import tempfile（第 5944 與 5974 行），為既有輕微問題。 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as 使用者
    participant line as line.py
    participant vw as ChatMoreOptions VirtualWindow
    participant dialog as 儲存對話框 (Win32)
    participant parser as _chatParser.py
    participant reader as _messageReader.py

    User->>line: script_openMessageReader()
    line->>line: _clickMoreOptionsButton()
    line->>vw: _activateMoreOptionsMenu()
    line->>vw: _messageReaderAutoClickSaveChat() [輪詢最多15次]
    vw-->>line: 點擊「儲存聊天」
    line->>dialog: _messageReaderHandleSaveDialog() [輪詢最多10次]
    dialog-->>line: dialogHwnd 找到
    line->>dialog: SendMessageW(WM_SETTEXT) 設定路徑
    line->>dialog: _messageReaderPressSave()
    dialog-->>line: 檔案儲存完成
    line->>line: _messageReaderHandleOverwrite() [覆寫確認]
    line->>line: _messageReaderOpenFile()
    line->>parser: parseChatFile(savePath)
    parser-->>line: messages[]
    line->>reader: openMessageReader(messages, cleanupPath=savePath)
    reader-->>User: 顯示訊息閱讀器對話框
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `addon/appModules/line.py`, line 5974 ([link](https://github.com/keyang556/linedesktopnvda/blob/2a67ed3d34cad2f943ccbedd6fec76aa2a0a795d/addon/appModules/line.py#L5974)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **重複的 `import tempfile`**

   `tempfile` 在同一函式的第 5944 行（函式頂端與 `ctypes` 一起匯入）已匯入過一次，第 5974 行再次匯入為多餘語句。Python 模組快取機制使此無害，但建議移除以保持程式碼簡潔。

   

   此為 PR #47 狀態即已存在的既有問題，非本次還原所引入。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: addon/appModules/line.py
   Line: 5974

   Comment:
   **重複的 `import tempfile`**

   `tempfile` 在同一函式的第 5944 行（函式頂端與 `ctypes` 一起匯入）已匯入過一次，第 5974 行再次匯入為多餘語句。Python 模組快取機制使此無害，但建議移除以保持程式碼簡潔。

   

   此為 PR #47 狀態即已存在的既有問題，非本次還原所引入。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%205974%0A%0AComment%3A%0A**%E9%87%8D%E8%A4%87%E7%9A%84%20%60import%20tempfile%60**%0A%0A%60tempfile%60%20%E5%9C%A8%E5%90%8C%E4%B8%80%E5%87%BD%E5%BC%8F%E7%9A%84%E7%AC%AC%205944%20%E8%A1%8C%EF%BC%88%E5%87%BD%E5%BC%8F%E9%A0%82%E7%AB%AF%E8%88%87%20%60ctypes%60%20%E4%B8%80%E8%B5%B7%E5%8C%AF%E5%85%A5%EF%BC%89%E5%B7%B2%E5%8C%AF%E5%85%A5%E9%81%8E%E4%B8%80%E6%AC%A1%EF%BC%8C%E7%AC%AC%205974%20%E8%A1%8C%E5%86%8D%E6%AC%A1%E5%8C%AF%E5%85%A5%E7%82%BA%E5%A4%9A%E9%A4%98%E8%AA%9E%E5%8F%A5%E3%80%82Python%20%E6%A8%A1%E7%B5%84%E5%BF%AB%E5%8F%96%E6%A9%9F%E5%88%B6%E4%BD%BF%E6%AD%A4%E7%84%A1%E5%AE%B3%EF%BC%8C%E4%BD%86%E5%BB%BA%E8%AD%B0%E7%A7%BB%E9%99%A4%E4%BB%A5%E4%BF%9D%E6%8C%81%E7%A8%8B%E5%BC%8F%E7%A2%BC%E7%B0%A1%E6%BD%94%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09savePath%20%3D%20os.path.join%28tempfile.gettempdir%28%29%2C%20%22lineDesktop_chat_export.txt%22%29%0A%60%60%60%0A%0A%E6%AD%A4%E7%82%BA%20PR%20%2347%20%E7%8B%80%E6%85%8B%E5%8D%B3%E5%B7%B2%E5%AD%98%E5%9C%A8%E7%9A%84%E6%97%A2%E6%9C%89%E5%95%8F%E9%A1%8C%EF%BC%8C%E9%9D%9E%E6%9C%AC%E6%AC%A1%E9%82%84%E5%8E%9F%E6%89%80%E5%BC%95%E5%85%A5%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=keyang556%2Flinedesktopnvda"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%205974%0A%0AComment%3A%0A**%E9%87%8D%E8%A4%87%E7%9A%84%20%60import%20tempfile%60**%0A%0A%60tempfile%60%20%E5%9C%A8%E5%90%8C%E4%B8%80%E5%87%BD%E5%BC%8F%E7%9A%84%E7%AC%AC%205944%20%E8%A1%8C%EF%BC%88%E5%87%BD%E5%BC%8F%E9%A0%82%E7%AB%AF%E8%88%87%20%60ctypes%60%20%E4%B8%80%E8%B5%B7%E5%8C%AF%E5%85%A5%EF%BC%89%E5%B7%B2%E5%8C%AF%E5%85%A5%E9%81%8E%E4%B8%80%E6%AC%A1%EF%BC%8C%E7%AC%AC%205974%20%E8%A1%8C%E5%86%8D%E6%AC%A1%E5%8C%AF%E5%85%A5%E7%82%BA%E5%A4%9A%E9%A4%98%E8%AA%9E%E5%8F%A5%E3%80%82Python%20%E6%A8%A1%E7%B5%84%E5%BF%AB%E5%8F%96%E6%A9%9F%E5%88%B6%E4%BD%BF%E6%AD%A4%E7%84%A1%E5%AE%B3%EF%BC%8C%E4%BD%86%E5%BB%BA%E8%AD%B0%E7%A7%BB%E9%99%A4%E4%BB%A5%E4%BF%9D%E6%8C%81%E7%A8%8B%E5%BC%8F%E7%A2%BC%E7%B0%A1%E6%BD%94%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09savePath%20%3D%20os.path.join%28tempfile.gettempdir%28%29%2C%20%22lineDesktop_chat_export.txt%22%29%0A%60%60%60%0A%0A%E6%AD%A4%E7%82%BA%20PR%20%2347%20%E7%8B%80%E6%85%8B%E5%8D%B3%E5%B7%B2%E5%AD%98%E5%9C%A8%E7%9A%84%E6%97%A2%E6%9C%89%E5%95%8F%E9%A1%8C%EF%BC%8C%E9%9D%9E%E6%9C%AC%E6%AC%A1%E9%82%84%E5%8E%9F%E6%89%80%E5%BC%95%E5%85%A5%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=keyang556%2Flinedesktopnvda"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A5974%0A**%E9%87%8D%E8%A4%87%E7%9A%84%20%60import%20tempfile%60**%0A%0A%60tempfile%60%20%E5%9C%A8%E5%90%8C%E4%B8%80%E5%87%BD%E5%BC%8F%E7%9A%84%E7%AC%AC%205944%20%E8%A1%8C%EF%BC%88%E5%87%BD%E5%BC%8F%E9%A0%82%E7%AB%AF%E8%88%87%20%60ctypes%60%20%E4%B8%80%E8%B5%B7%E5%8C%AF%E5%85%A5%EF%BC%89%E5%B7%B2%E5%8C%AF%E5%85%A5%E9%81%8E%E4%B8%80%E6%AC%A1%EF%BC%8C%E7%AC%AC%205974%20%E8%A1%8C%E5%86%8D%E6%AC%A1%E5%8C%AF%E5%85%A5%E7%82%BA%E5%A4%9A%E9%A4%98%E8%AA%9E%E5%8F%A5%E3%80%82Python%20%E6%A8%A1%E7%B5%84%E5%BF%AB%E5%8F%96%E6%A9%9F%E5%88%B6%E4%BD%BF%E6%AD%A4%E7%84%A1%E5%AE%B3%EF%BC%8C%E4%BD%86%E5%BB%BA%E8%AD%B0%E7%A7%BB%E9%99%A4%E4%BB%A5%E4%BF%9D%E6%8C%81%E7%A8%8B%E5%BC%8F%E7%A2%BC%E7%B0%A1%E6%BD%94%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09savePath%20%3D%20os.path.join%28tempfile.gettempdir%28%29%2C%20%22lineDesktop_chat_export.txt%22%29%0A%60%60%60%0A%0A%E6%AD%A4%E7%82%BA%20PR%20%2347%20%E7%8B%80%E6%85%8B%E5%8D%B3%E5%B7%B2%E5%AD%98%E5%9C%A8%E7%9A%84%E6%97%A2%E6%9C%89%E5%95%8F%E9%A1%8C%EF%BC%8C%E9%9D%9E%E6%9C%AC%E6%AC%A1%E9%82%84%E5%8E%9F%E6%89%80%E5%BC%95%E5%85%A5%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A5974%0A**%E9%87%8D%E8%A4%87%E7%9A%84%20%60import%20tempfile%60**%0A%0A%60tempfile%60%20%E5%9C%A8%E5%90%8C%E4%B8%80%E5%87%BD%E5%BC%8F%E7%9A%84%E7%AC%AC%205944%20%E8%A1%8C%EF%BC%88%E5%87%BD%E5%BC%8F%E9%A0%82%E7%AB%AF%E8%88%87%20%60ctypes%60%20%E4%B8%80%E8%B5%B7%E5%8C%AF%E5%85%A5%EF%BC%89%E5%B7%B2%E5%8C%AF%E5%85%A5%E9%81%8E%E4%B8%80%E6%AC%A1%EF%BC%8C%E7%AC%AC%205974%20%E8%A1%8C%E5%86%8D%E6%AC%A1%E5%8C%AF%E5%85%A5%E7%82%BA%E5%A4%9A%E9%A4%98%E8%AA%9E%E5%8F%A5%E3%80%82Python%20%E6%A8%A1%E7%B5%84%E5%BF%AB%E5%8F%96%E6%A9%9F%E5%88%B6%E4%BD%BF%E6%AD%A4%E7%84%A1%E5%AE%B3%EF%BC%8C%E4%BD%86%E5%BB%BA%E8%AD%B0%E7%A7%BB%E9%99%A4%E4%BB%A5%E4%BF%9D%E6%8C%81%E7%A8%8B%E5%BC%8F%E7%A2%BC%E7%B0%A1%E6%BD%94%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09savePath%20%3D%20os.path.join%28tempfile.gettempdir%28%29%2C%20%22lineDesktop_chat_export.txt%22%29%0A%60%60%60%0A%0A%E6%AD%A4%E7%82%BA%20PR%20%2347%20%E7%8B%80%E6%85%8B%E5%8D%B3%E5%B7%B2%E5%AD%98%E5%9C%A8%E7%9A%84%E6%97%A2%E6%9C%89%E5%95%8F%E9%A1%8C%EF%BC%8C%E9%9D%9E%E6%9C%AC%E6%AC%A1%E9%82%84%E5%8E%9F%E6%89%80%E5%BC%95%E5%85%A5%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 5974

Comment:
**重複的 `import tempfile`**

`tempfile` 在同一函式的第 5944 行（函式頂端與 `ctypes` 一起匯入）已匯入過一次，第 5974 行再次匯入為多餘語句。Python 模組快取機制使此無害，但建議移除以保持程式碼簡潔。

```suggestion
		savePath = os.path.join(tempfile.gettempdir(), "lineDesktop_chat_export.txt")
```

此為 PR #47 狀態即已存在的既有問題，非本次還原所引入。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;訊息閱讀器功能改進與 bug 修正&quot;"](https://github.com/keyang556/linedesktopnvda/commit/2a67ed3d34cad2f943ccbedd6fec76aa2a0a795d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27816419)</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->