### PR TITLE
Fix braille crash when zh-tw.ctb cannot translate Chinese text

### DIFF
--- a/addon/appModules/_utils.py
+++ b/addon/appModules/_utils.py
@@ -84,13 +84,16 @@ def message(text):
 	
 	handler = braille.handler
 	assert handler
-	if handler.buffer is handler.messageBuffer:
-		handler.buffer.clear()
-	else:
-		handler.buffer = handler.messageBuffer
-	
-	region = braille.TextRegion(text)
-	region.update()
-	handler.buffer.regions.append(region)
-	handler.buffer.update()
-	handler.update()
+	try:
+		if handler.buffer is handler.messageBuffer:
+			handler.buffer.clear()
+		else:
+			handler.buffer = handler.messageBuffer
+
+		region = braille.TextRegion(text)
+		region.update()
+		handler.buffer.regions.append(region)
+		handler.buffer.update()
+		handler.update()
+	except RuntimeError:
+		log.debug("Braille translation failed for text, skipping braille output", exc_info=True)

--- a/build_addon.py
+++ b/build_addon.py
@@ -10,7 +10,7 @@ import subprocess
 import markdown
 
 ADDON_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "addon")
-OUTPUT_NAME = "lineDesktop-1.2.2.nvda-addon"
+OUTPUT_NAME = "lineDesktop-1.2.3-beta2.nvda-addon"
 OUTPUT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), OUTPUT_NAME)
 
 # Manifest content matching the format of working NVDA add-ons
@@ -19,9 +19,9 @@ name = lineDesktop
 summary = "LINE Desktop Accessibility"
 description = \"\"\"Enhances NVDA accessibility support for the LINE desktop application on Windows.
 Provides improved navigation for chat lists, messages, contacts, and message input.\"\"\"
-author = "張可揚 <lindsay714322@gmail.com>; 洪鳳恩 <kittyhong0208@gmail.com>"
+author = "張可揚 <lindsay714322@gmail.com>; 洪鳳恩 <kittyhong0208@gmail.com>; 蔡頭<tommytsaitou>"
 url = None
-version = 1.2.2
+version = 1.2.3beta2
 changelog = \"\"\"Initial release with LINE desktop accessibility support.\"\"\"
 docFileName = readme.html
 minimumNVDAVersion = 2019.3


### PR DESCRIPTION
## Summary
- Wraps braille display calls in the `message()` function with a try-except to gracefully handle `RuntimeError` from liblouis
- Fixes crashes when liblouis fails to translate Chinese characters with the zh-tw.ctb table
- Speech output is unaffected; braille output is silently skipped with a debug log entry

## Test plan
- Verify that the "more options" menu (NVDA+Windows+O) works without crashing
- Check NVDA logs to confirm debug message appears when braille translation fails

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 修復了當 liblouis 無法使用 `zh-tw.ctb` 點字表翻譯中文字元時，`message()` 函式中點字顯示邏輯造成崩潰的問題。修復方式為在點字相關操作外層加上 `try-except RuntimeError`，讓語音輸出不受影響，並在點字翻譯失敗時靜默跳過並記錄 debug 日誌。同時附帶版本升級至 `1.2.3-beta2` 及新增貢獻者資訊。

主要變更：
- `addon/appModules/_utils.py`：`message()` 函式中的點字操作現在能優雅地處理 `RuntimeError`，避免崩潰。
- `build_addon.py`：版本號從 `1.2.2` 升至 `1.2.3beta2`，並新增作者 `蔡頭`。
- 需注意：`OUTPUT_NAME` 與 manifest `version` 欄位的格式有些微不一致（連字號差異），以及新作者欄位格式不符合慣例（缺空格、無有效電子郵件）。

<h3>Confidence Score: 4/5</h3>

此 PR 可安全合併，修復了確實存在的崩潰問題，僅有少數非關鍵的格式問題需後續處理。

核心修復邏輯正確且有針對性——捕獲 RuntimeError 是 liblouis 翻譯失敗的確切例外類型，語音輸出完全不受影響。扣一分是因為在 else 分支下存在輕微的緩衝區狀態不一致可能性，以及 build_addon.py 中版本格式與作者欄位的格式問題。

請留意 build_addon.py 中 OUTPUT_NAME 與 manifest version 欄位的格式差異，以及作者欄位格式問題。

<details open><summary><h3>Vulnerabilities</h3></summary>

未發現安全問題。點字例外處理僅捕獲 `RuntimeError` 並記錄 debug 日誌，不涉及使用者輸入驗證、憑證處理或任何敏感資料暴露。
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/_utils.py | 將點字顯示呼叫包裹於 try-except(RuntimeError) 中，防止 liblouis 無法翻譯中文字元時造成崩潰；但在 else 分支修改 handler.buffer 後發生例外時，緩衝區指向可能殘留不一致狀態。 |
| build_addon.py | 版本號從 1.2.2 升至 1.2.3-beta2 並新增作者，但 OUTPUT_NAME 與 manifest version 格式不一致（連字號差異），且新增作者欄位缺少空格且無有效電子郵件。 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["message(text) 呼叫"] --> B["speech.speakMessage(text)\n語音輸出（不受影響）"]
    B --> C["取得 braille.handler\nassert handler"]
    C --> D{"handler.buffer\nis messageBuffer?"}
    D -->|"是（path A）"| E["handler.buffer.clear()"]
    D -->|"否（path B）"| F["handler.buffer = handler.messageBuffer"]
    E --> G["braille.TextRegion(text)"]
    F --> G
    G --> H["region.update()\n呼叫 liblouis 翻譯"]
    H -->|"成功"| I["buffer.regions.append(region)\nbuffer.update()\nhandler.update()"]
    H -->|"RuntimeError\nliblouis 翻譯失敗"| J["捕獲 RuntimeError"]
    J --> K["log.debug(...)\n靜默記錄，跳過點字輸出"]
    I --> L["點字顯示器更新完成"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aaddon%2FappModules%2F_utils.py%3A87-99%0A**%E7%B7%A9%E8%A1%9D%E5%8D%80%E7%8B%80%E6%85%8B%E5%9C%A8%E4%BE%8B%E5%A4%96%E7%99%BC%E7%94%9F%E5%BE%8C%E5%8F%AF%E8%83%BD%E4%B8%8D%E4%B8%80%E8%87%B4**%0A%0A%E7%95%B6%20%60handler.buffer%60%20%E5%8E%9F%E6%9C%AC**%E4%B8%8D%E6%98%AF**%20%60handler.messageBuffer%60%EF%BC%88%E9%80%B2%E5%85%A5%20%60else%60%20%E5%88%86%E6%94%AF%EF%BC%89%E6%99%82%EF%BC%8C%60handler.buffer%20%3D%20handler.messageBuffer%60%20%E5%B7%B2%E8%A2%AB%E5%9F%B7%E8%A1%8C%EF%BC%8C%E4%BD%86%E8%8B%A5%E9%9A%A8%E5%BE%8C%20%60region.update%28%29%60%20%E6%8B%8B%E5%87%BA%20%60RuntimeError%60%EF%BC%8C%60handler.messageBuffer%60%20%E7%9A%84%E5%85%A7%E5%AE%B9%E4%B8%A6%E6%9C%AA%E8%A2%AB%E6%B8%85%E9%99%A4%EF%BC%8C%E4%B8%94%20%60handler.buffer%60%20%E5%B7%B2%E6%8C%87%E5%90%91%20%60messageBuffer%60%E3%80%82%0A%0A%E9%9B%96%E7%84%B6%E5%9B%A0%E7%82%BA%20%60handler.update%28%29%60%20%E5%BE%9E%E6%9C%AA%E8%A2%AB%E5%91%BC%E5%8F%AB%EF%BC%8C%E6%89%80%E4%BB%A5%E5%AF%A6%E9%AB%94%E9%BB%9E%E5%AD%97%E9%A1%AF%E7%A4%BA%E5%99%A8%E4%B8%8D%E6%9C%83%E7%AB%8B%E5%88%BB%E6%9B%B4%E6%96%B0%EF%BC%8C%E4%BD%86%20%60handler.buffer%60%20%E7%9A%84%E6%8C%87%E5%90%91%E5%B7%B2%E6%82%84%E7%84%B6%E6%94%B9%E8%AE%8A%E3%80%82%E8%8B%A5%20NVDA%20%E5%85%A7%E9%83%A8%E5%85%B6%E4%BB%96%E6%A9%9F%E5%88%B6%E5%9C%A8%E6%AD%A4%E4%B9%8B%E5%BE%8C%E5%91%BC%E5%8F%AB%20%60handler.update%28%29%60%EF%BC%8C%E5%8F%AF%E8%83%BD%E6%9C%83%E5%B0%87%20%60messageBuffer%60%20%E4%B8%AD%E6%AE%98%E7%95%99%E7%9A%84%E8%88%8A%E5%85%A7%E5%AE%B9%E9%A1%AF%E7%A4%BA%E5%9C%A8%E9%BB%9E%E5%AD%97%E6%A9%9F%E4%B8%8A%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%9C%A8%E6%8D%95%E7%8D%B2%E4%BE%8B%E5%A4%96%E6%99%82%EF%BC%8C%E8%A6%96%E6%83%85%E6%B3%81%E5%B0%87%20%60handler.buffer%60%20%E9%82%84%E5%8E%9F%EF%BC%9A%0A%0A%60%60%60python%0Atry%3A%0A%20%20%20%20original_buffer%20%3D%20handler.buffer%0A%20%20%20%20if%20handler.buffer%20is%20handler.messageBuffer%3A%0A%20%20%20%20%20%20%20%20handler.buffer.clear%28%29%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20handler.buffer%20%3D%20handler.messageBuffer%0A%0A%20%20%20%20region%20%3D%20braille.TextRegion%28text%29%0A%20%20%20%20region.update%28%29%0A%20%20%20%20handler.buffer.regions.append%28region%29%0A%20%20%20%20handler.buffer.update%28%29%0A%20%20%20%20handler.update%28%29%0Aexcept%20RuntimeError%3A%0A%20%20%20%20handler.buffer%20%3D%20original_buffer%20%20%23%20%E9%82%84%E5%8E%9F%E7%B7%A9%E8%A1%9D%E5%8D%80%E6%8C%87%E5%90%91%0A%20%20%20%20log.debug%28%22Braille%20translation%20failed%20for%20text%2C%20skipping%20braille%20output%22%2C%20exc_info%3DTrue%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abuild_addon.py%3A13-27%0A**%E7%89%88%E6%9C%AC%E5%AD%97%E4%B8%B2%E6%A0%BC%E5%BC%8F%E4%B8%8D%E4%B8%80%E8%87%B4**%0A%0A%60OUTPUT_NAME%60%EF%BC%88%E7%AC%AC%2013%20%E8%A1%8C%EF%BC%89%E4%BD%BF%E7%94%A8%20%601.2.3-beta2%60%EF%BC%88%E5%90%AB%E9%80%A3%E5%AD%97%E8%99%9F%EF%BC%89%EF%BC%8C%E4%BD%86%20manifest%20%E4%B8%AD%E7%9A%84%20%60version%60%EF%BC%88%E7%AC%AC%2027%20%E8%A1%8C%EF%BC%89%E4%BD%BF%E7%94%A8%20%601.2.3beta2%60%EF%BC%88%E7%84%A1%E9%80%A3%E5%AD%97%E8%99%9F%EF%BC%89%E3%80%82%E8%8B%A5%20NVDA%20%E6%A0%B9%E6%93%9A%20manifest%20%E4%B8%AD%E7%9A%84%20%60version%60%20%E6%AC%84%E4%BD%8D%E9%80%B2%E8%A1%8C%E7%89%88%E6%9C%AC%E6%AF%94%E5%B0%8D%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E7%9C%8B%E5%88%B0%E7%9A%84%E6%AA%94%E6%A1%88%E5%90%8D%E7%A8%B1%E8%88%87%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E7%AE%A1%E7%90%86%E5%93%A1%E9%A1%AF%E7%A4%BA%E7%9A%84%E7%89%88%E6%9C%AC%E8%99%9F%E5%B0%87%E4%B8%8D%E4%B8%80%E8%87%B4%EF%BC%8C%E5%8F%AF%E8%83%BD%E9%80%A0%E6%88%90%E6%B7%B7%E6%B7%86%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E7%B5%B1%E4%B8%80%E6%A0%BC%E5%BC%8F%EF%BC%9A%0A%0A%60%60%60suggestion%0Aversion%20%3D%201.2.3-beta2%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abuild_addon.py%3A22%0A**%E4%BD%9C%E8%80%85%E6%AC%84%E4%BD%8D%E6%A0%BC%E5%BC%8F%E5%95%8F%E9%A1%8C**%0A%0A%60%E8%94%A1%E9%A0%AD%3Ctommytsaitou%3E%60%20%E7%BC%BA%E5%B0%91%E5%90%8D%E7%A8%B1%E8%88%87%E8%A7%92%E6%8B%AC%E8%99%9F%E4%B9%8B%E9%96%93%E7%9A%84%E7%A9%BA%E6%A0%BC%EF%BC%8C%E4%B8%94%20%60tommytsaitou%60%20%E4%B8%8D%E6%98%AF%E6%9C%89%E6%95%88%E7%9A%84%E9%9B%BB%E5%AD%90%E9%83%B5%E4%BB%B6%E5%9C%B0%E5%9D%80%EF%BC%8C%E8%88%87%E5%85%B6%E4%BB%96%E4%BD%9C%E8%80%85%E7%9A%84%E6%A0%BC%E5%BC%8F%20%60%E5%A7%93%E5%90%8D%20%3Cemail%3E%60%20%E4%B8%8D%E7%AC%A6%E3%80%82%E8%8B%A5%20NVDA%20%E7%9A%84%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E7%AE%A1%E7%90%86%E5%93%A1%E6%88%96%E6%9B%B4%E6%96%B0%E6%A9%9F%E5%88%B6%E8%A7%A3%E6%9E%90%E6%AD%A4%E6%AC%84%E4%BD%8D%EF%BC%8C%E5%8F%AF%E8%83%BD%E7%99%BC%E7%94%9F%E6%A0%BC%E5%BC%8F%E9%8C%AF%E8%AA%A4%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E4%BF%AE%E6%AD%A3%E6%A0%BC%E5%BC%8F%EF%BC%9A%0A%0A%60%60%60suggestion%0Aauthor%20%3D%20%22%E5%BC%B5%E5%8F%AF%E6%8F%9A%20%3Clindsay714322%40gmail.com%3E%3B%20%E6%B4%AA%E9%B3%B3%E6%81%A9%20%3Ckittyhong0208%40gmail.com%3E%3B%20%E8%94%A1%E9%A0%AD%20%3Ctommytsaitou%40example.com%3E%22%0A%60%60%60%0A%0A%E8%AB%8B%E5%B0%87%20%60tommytsaitou%40example.com%60%20%E6%9B%BF%E6%8F%9B%E7%82%BA%E5%AF%A6%E9%9A%9B%E7%9A%84%E9%9B%BB%E5%AD%90%E9%83%B5%E4%BB%B6%E5%9C%B0%E5%9D%80%EF%BC%88%E8%8B%A5%E7%84%A1%E6%AD%A3%E5%BC%8F%E9%9B%BB%E5%AD%90%E9%83%B5%E4%BB%B6%EF%BC%8C%E5%8F%AF%E4%BD%BF%E7%94%A8%20GitHub%20%E7%9A%84%20noreply%20%E6%A0%BC%E5%BC%8F%EF%BC%89%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aaddon%2FappModules%2F_utils.py%3A87-99%0A**%E7%B7%A9%E8%A1%9D%E5%8D%80%E7%8B%80%E6%85%8B%E5%9C%A8%E4%BE%8B%E5%A4%96%E7%99%BC%E7%94%9F%E5%BE%8C%E5%8F%AF%E8%83%BD%E4%B8%8D%E4%B8%80%E8%87%B4**%0A%0A%E7%95%B6%20%60handler.buffer%60%20%E5%8E%9F%E6%9C%AC**%E4%B8%8D%E6%98%AF**%20%60handler.messageBuffer%60%EF%BC%88%E9%80%B2%E5%85%A5%20%60else%60%20%E5%88%86%E6%94%AF%EF%BC%89%E6%99%82%EF%BC%8C%60handler.buffer%20%3D%20handler.messageBuffer%60%20%E5%B7%B2%E8%A2%AB%E5%9F%B7%E8%A1%8C%EF%BC%8C%E4%BD%86%E8%8B%A5%E9%9A%A8%E5%BE%8C%20%60region.update%28%29%60%20%E6%8B%8B%E5%87%BA%20%60RuntimeError%60%EF%BC%8C%60handler.messageBuffer%60%20%E7%9A%84%E5%85%A7%E5%AE%B9%E4%B8%A6%E6%9C%AA%E8%A2%AB%E6%B8%85%E9%99%A4%EF%BC%8C%E4%B8%94%20%60handler.buffer%60%20%E5%B7%B2%E6%8C%87%E5%90%91%20%60messageBuffer%60%E3%80%82%0A%0A%E9%9B%96%E7%84%B6%E5%9B%A0%E7%82%BA%20%60handler.update%28%29%60%20%E5%BE%9E%E6%9C%AA%E8%A2%AB%E5%91%BC%E5%8F%AB%EF%BC%8C%E6%89%80%E4%BB%A5%E5%AF%A6%E9%AB%94%E9%BB%9E%E5%AD%97%E9%A1%AF%E7%A4%BA%E5%99%A8%E4%B8%8D%E6%9C%83%E7%AB%8B%E5%88%BB%E6%9B%B4%E6%96%B0%EF%BC%8C%E4%BD%86%20%60handler.buffer%60%20%E7%9A%84%E6%8C%87%E5%90%91%E5%B7%B2%E6%82%84%E7%84%B6%E6%94%B9%E8%AE%8A%E3%80%82%E8%8B%A5%20NVDA%20%E5%85%A7%E9%83%A8%E5%85%B6%E4%BB%96%E6%A9%9F%E5%88%B6%E5%9C%A8%E6%AD%A4%E4%B9%8B%E5%BE%8C%E5%91%BC%E5%8F%AB%20%60handler.update%28%29%60%EF%BC%8C%E5%8F%AF%E8%83%BD%E6%9C%83%E5%B0%87%20%60messageBuffer%60%20%E4%B8%AD%E6%AE%98%E7%95%99%E7%9A%84%E8%88%8A%E5%85%A7%E5%AE%B9%E9%A1%AF%E7%A4%BA%E5%9C%A8%E9%BB%9E%E5%AD%97%E6%A9%9F%E4%B8%8A%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%9C%A8%E6%8D%95%E7%8D%B2%E4%BE%8B%E5%A4%96%E6%99%82%EF%BC%8C%E8%A6%96%E6%83%85%E6%B3%81%E5%B0%87%20%60handler.buffer%60%20%E9%82%84%E5%8E%9F%EF%BC%9A%0A%0A%60%60%60python%0Atry%3A%0A%20%20%20%20original_buffer%20%3D%20handler.buffer%0A%20%20%20%20if%20handler.buffer%20is%20handler.messageBuffer%3A%0A%20%20%20%20%20%20%20%20handler.buffer.clear%28%29%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20handler.buffer%20%3D%20handler.messageBuffer%0A%0A%20%20%20%20region%20%3D%20braille.TextRegion%28text%29%0A%20%20%20%20region.update%28%29%0A%20%20%20%20handler.buffer.regions.append%28region%29%0A%20%20%20%20handler.buffer.update%28%29%0A%20%20%20%20handler.update%28%29%0Aexcept%20RuntimeError%3A%0A%20%20%20%20handler.buffer%20%3D%20original_buffer%20%20%23%20%E9%82%84%E5%8E%9F%E7%B7%A9%E8%A1%9D%E5%8D%80%E6%8C%87%E5%90%91%0A%20%20%20%20log.debug%28%22Braille%20translation%20failed%20for%20text%2C%20skipping%20braille%20output%22%2C%20exc_info%3DTrue%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Abuild_addon.py%3A13-27%0A**%E7%89%88%E6%9C%AC%E5%AD%97%E4%B8%B2%E6%A0%BC%E5%BC%8F%E4%B8%8D%E4%B8%80%E8%87%B4**%0A%0A%60OUTPUT_NAME%60%EF%BC%88%E7%AC%AC%2013%20%E8%A1%8C%EF%BC%89%E4%BD%BF%E7%94%A8%20%601.2.3-beta2%60%EF%BC%88%E5%90%AB%E9%80%A3%E5%AD%97%E8%99%9F%EF%BC%89%EF%BC%8C%E4%BD%86%20manifest%20%E4%B8%AD%E7%9A%84%20%60version%60%EF%BC%88%E7%AC%AC%2027%20%E8%A1%8C%EF%BC%89%E4%BD%BF%E7%94%A8%20%601.2.3beta2%60%EF%BC%88%E7%84%A1%E9%80%A3%E5%AD%97%E8%99%9F%EF%BC%89%E3%80%82%E8%8B%A5%20NVDA%20%E6%A0%B9%E6%93%9A%20manifest%20%E4%B8%AD%E7%9A%84%20%60version%60%20%E6%AC%84%E4%BD%8D%E9%80%B2%E8%A1%8C%E7%89%88%E6%9C%AC%E6%AF%94%E5%B0%8D%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E7%9C%8B%E5%88%B0%E7%9A%84%E6%AA%94%E6%A1%88%E5%90%8D%E7%A8%B1%E8%88%87%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E7%AE%A1%E7%90%86%E5%93%A1%E9%A1%AF%E7%A4%BA%E7%9A%84%E7%89%88%E6%9C%AC%E8%99%9F%E5%B0%87%E4%B8%8D%E4%B8%80%E8%87%B4%EF%BC%8C%E5%8F%AF%E8%83%BD%E9%80%A0%E6%88%90%E6%B7%B7%E6%B7%86%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E7%B5%B1%E4%B8%80%E6%A0%BC%E5%BC%8F%EF%BC%9A%0A%0A%60%60%60suggestion%0Aversion%20%3D%201.2.3-beta2%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Abuild_addon.py%3A22%0A**%E4%BD%9C%E8%80%85%E6%AC%84%E4%BD%8D%E6%A0%BC%E5%BC%8F%E5%95%8F%E9%A1%8C**%0A%0A%60%E8%94%A1%E9%A0%AD%3Ctommytsaitou%3E%60%20%E7%BC%BA%E5%B0%91%E5%90%8D%E7%A8%B1%E8%88%87%E8%A7%92%E6%8B%AC%E8%99%9F%E4%B9%8B%E9%96%93%E7%9A%84%E7%A9%BA%E6%A0%BC%EF%BC%8C%E4%B8%94%20%60tommytsaitou%60%20%E4%B8%8D%E6%98%AF%E6%9C%89%E6%95%88%E7%9A%84%E9%9B%BB%E5%AD%90%E9%83%B5%E4%BB%B6%E5%9C%B0%E5%9D%80%EF%BC%8C%E8%88%87%E5%85%B6%E4%BB%96%E4%BD%9C%E8%80%85%E7%9A%84%E6%A0%BC%E5%BC%8F%20%60%E5%A7%93%E5%90%8D%20%3Cemail%3E%60%20%E4%B8%8D%E7%AC%A6%E3%80%82%E8%8B%A5%20NVDA%20%E7%9A%84%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E7%AE%A1%E7%90%86%E5%93%A1%E6%88%96%E6%9B%B4%E6%96%B0%E6%A9%9F%E5%88%B6%E8%A7%A3%E6%9E%90%E6%AD%A4%E6%AC%84%E4%BD%8D%EF%BC%8C%E5%8F%AF%E8%83%BD%E7%99%BC%E7%94%9F%E6%A0%BC%E5%BC%8F%E9%8C%AF%E8%AA%A4%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E4%BF%AE%E6%AD%A3%E6%A0%BC%E5%BC%8F%EF%BC%9A%0A%0A%60%60%60suggestion%0Aauthor%20%3D%20%22%E5%BC%B5%E5%8F%AF%E6%8F%9A%20%3Clindsay714322%40gmail.com%3E%3B%20%E6%B4%AA%E9%B3%B3%E6%81%A9%20%3Ckittyhong0208%40gmail.com%3E%3B%20%E8%94%A1%E9%A0%AD%20%3Ctommytsaitou%40example.com%3E%22%0A%60%60%60%0A%0A%E8%AB%8B%E5%B0%87%20%60tommytsaitou%40example.com%60%20%E6%9B%BF%E6%8F%9B%E7%82%BA%E5%AF%A6%E9%9A%9B%E7%9A%84%E9%9B%BB%E5%AD%90%E9%83%B5%E4%BB%B6%E5%9C%B0%E5%9D%80%EF%BC%88%E8%8B%A5%E7%84%A1%E6%AD%A3%E5%BC%8F%E9%9B%BB%E5%AD%90%E9%83%B5%E4%BB%B6%EF%BC%8C%E5%8F%AF%E4%BD%BF%E7%94%A8%20GitHub%20%E7%9A%84%20noreply%20%E6%A0%BC%E5%BC%8F%EF%BC%89%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/_utils.py
Line: 87-99

Comment:
**緩衝區狀態在例外發生後可能不一致**

當 `handler.buffer` 原本**不是** `handler.messageBuffer`（進入 `else` 分支）時，`handler.buffer = handler.messageBuffer` 已被執行，但若隨後 `region.update()` 拋出 `RuntimeError`，`handler.messageBuffer` 的內容並未被清除，且 `handler.buffer` 已指向 `messageBuffer`。

雖然因為 `handler.update()` 從未被呼叫，所以實體點字顯示器不會立刻更新，但 `handler.buffer` 的指向已悄然改變。若 NVDA 內部其他機制在此之後呼叫 `handler.update()`，可能會將 `messageBuffer` 中殘留的舊內容顯示在點字機上。

建議在捕獲例外時，視情況將 `handler.buffer` 還原：

```python
try:
    original_buffer = handler.buffer
    if handler.buffer is handler.messageBuffer:
        handler.buffer.clear()
    else:
        handler.buffer = handler.messageBuffer

    region = braille.TextRegion(text)
    region.update()
    handler.buffer.regions.append(region)
    handler.buffer.update()
    handler.update()
except RuntimeError:
    handler.buffer = original_buffer  # 還原緩衝區指向
    log.debug("Braille translation failed for text, skipping braille output", exc_info=True)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: build_addon.py
Line: 13-27

Comment:
**版本字串格式不一致**

`OUTPUT_NAME`（第 13 行）使用 `1.2.3-beta2`（含連字號），但 manifest 中的 `version`（第 27 行）使用 `1.2.3beta2`（無連字號）。若 NVDA 根據 manifest 中的 `version` 欄位進行版本比對，使用者看到的檔案名稱與附加元件管理員顯示的版本號將不一致，可能造成混淆。

建議統一格式：

```suggestion
version = 1.2.3-beta2
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: build_addon.py
Line: 22

Comment:
**作者欄位格式問題**

`蔡頭<tommytsaitou>` 缺少名稱與角括號之間的空格，且 `tommytsaitou` 不是有效的電子郵件地址，與其他作者的格式 `姓名 <email>` 不符。若 NVDA 的附加元件管理員或更新機制解析此欄位，可能發生格式錯誤。

建議修正格式：

```suggestion
author = "張可揚 <lindsay714322@gmail.com>; 洪鳳恩 <kittyhong0208@gmail.com>; 蔡頭 <tommytsaitou@example.com>"
```

請將 `tommytsaitou@example.com` 替換為實際的電子郵件地址（若無正式電子郵件，可使用 GitHub 的 noreply 格式）。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix braille crash when zh-tw.ctb cannot ..."](https://github.com/keyang556/linedesktopnvda/commit/365fe869d2dc9d80c1aa8beaf3681e1bdf5a023c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27817762)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->