### PR TITLE
Add LINE version detection and ChatWindow mode support

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -23,10 +23,154 @@ import ctypes.wintypes
 import comtypes
 import re
 import time
+import configparser
 from ._virtualWindow import VirtualWindow
 import addonHandler
 
 addonHandler.initTranslation()
+
+
+# ---------------------------------------------------------------------------
+# LINE installation info — version detection and window type classification
+# ---------------------------------------------------------------------------
+
+def _getLineDataDir():
+	"""Return the LINE data directory path, or None if not found."""
+	localAppData = os.environ.get("LOCALAPPDATA", "")
+	if not localAppData:
+		return None
+	lineDataDir = os.path.join(localAppData, "LINE", "Data")
+	if os.path.isdir(lineDataDir):
+		return lineDataDir
+	return None
+
+
+def _readLineVersion():
+	"""Read the installed LINE version from LINE.ini.
+
+	Returns the version string (e.g. '26.1.0.3865') or None.
+	"""
+	dataDir = _getLineDataDir()
+	if not dataDir:
+		return None
+	iniPath = os.path.join(dataDir, "LINE.ini")
+	if not os.path.isfile(iniPath):
+		return None
+	try:
+		parser = configparser.ConfigParser()
+		parser.read(iniPath, encoding="utf-8")
+		return parser.get("global", "last_updated_version", fallback=None)
+	except Exception:
+		return None
+
+
+def _readLineLanguage():
+	"""Read the LINE UI language from installLang.ini.
+
+	Returns the language code (e.g. 'zh-TW') or None.
+	"""
+	dataDir = _getLineDataDir()
+	if not dataDir:
+		return None
+	iniPath = os.path.join(dataDir, "installLang.ini")
+	if not os.path.isfile(iniPath):
+		return None
+	try:
+		parser = configparser.ConfigParser()
+		parser.read(iniPath, encoding="utf-8")
+		return parser.get("General", "installLang", fallback=None)
+	except Exception:
+		return None
+
+
+# Window type classification —
+# LINE has two main window modes:
+#   "AllInOneWindow" — sidebar (chat list) + chat area in one window
+#   "ChatWindow" — standalone chat window (no sidebar)
+# In ChatWindow mode, all list items are message items (no sidebar heuristic needed).
+
+# Cache to avoid repeated window classification within the same focus cycle.
+_windowTypeCache = {
+	"hwnd": None,
+	"type": None,      # "allinone", "chat", or "unknown"
+	"expiresAt": 0.0,
+}
+_WINDOW_TYPE_CACHE_TTL = 2.0  # seconds
+
+
+def _classifyLineWindow(hwnd=None):
+	"""Classify the current LINE window as 'allinone', 'chat', or 'unknown'.
+
+	Uses window dimensions as heuristic:
+	  - AllInOneWindow is wider (has sidebar ~250-350px + chat area)
+	  - ChatWindow is narrower (chat area only, typically < 500px wide)
+	Also checks UIA tree for sidebar list presence as a secondary signal.
+	"""
+	global _windowTypeCache
+
+	if hwnd is None:
+		hwnd = ctypes.windll.user32.GetForegroundWindow()
+	if not hwnd:
+		return "unknown"
+
+	now = time.monotonic()
+	cache = _windowTypeCache
+	if cache["hwnd"] == int(hwnd) and cache["expiresAt"] > now:
+		return cache["type"]
+
+	windowType = "unknown"
+	try:
+		rect = ctypes.wintypes.RECT()
+		ctypes.windll.user32.GetWindowRect(hwnd, ctypes.byref(rect))
+		winWidth = rect.right - rect.left
+
+		# AllInOneWindow typically has sidebar (~250-350px) + chat area (~400px+)
+		# so total width >= ~600px. ChatWindow is standalone chat, narrower.
+		# However, users can resize. Use a soft threshold + child window count.
+		if winWidth >= 600:
+			# Likely AllInOneWindow, but could be a wide ChatWindow.
+			# Check for the presence of multiple pane children (sidebar + chat)
+			# via quick UIA check.
+			try:
+				handler = UIAHandler.handler
+				if handler:
+					walker = handler.clientObject.RawViewWalker
+					rootCond = handler.clientObject.CreatePropertyCondition(
+						30003, 50033  # ControlType == Pane
+					)
+					rootEl = handler.clientObject.ElementFromHandle(hwnd)
+					if rootEl:
+						panes = rootEl.FindAll(2, rootCond)  # TreeScope.Children=2
+						paneCount = panes.Length if panes else 0
+						if paneCount >= 2:
+							windowType = "allinone"
+						else:
+							# Single pane or no panes — could be ChatWindow
+							# at larger size
+							windowType = "allinone" if winWidth >= 700 else "chat"
+			except Exception:
+				# Fallback: wide window is likely AllInOneWindow
+				windowType = "allinone"
+		else:
+			windowType = "chat"
+
+	except Exception:
+		log.debug("_classifyLineWindow failed", exc_info=True)
+
+	cache["hwnd"] = int(hwnd)
+	cache["type"] = windowType
+	cache["expiresAt"] = now + _WINDOW_TYPE_CACHE_TTL
+	log.debug(f"LINE: window type classified as '{windowType}' (hwnd={hwnd})")
+	return windowType
+
+
+def _isChatWindowMode(hwnd=None):
+	"""Return True if the current LINE window is a standalone ChatWindow.
+
+	In ChatWindow mode, there is no sidebar — all list items are message items.
+	"""
+	return _classifyLineWindow(hwnd) == "chat"
+
 
 # Sound file to play after a message is successfully sent
 _SEND_SOUND_PATH = os.path.join(
@@ -1868,6 +2012,10 @@ def _isInChatListContext(handler):
 		if ct == 50007:  # ListItem - focus is on a list item already
 			listEl, walker = _findListElement(handler, rawElement)
 			if listEl:
+				# In standalone ChatWindow mode there is no sidebar —
+				# all lists are message lists, not chat lists.
+				if _isChatWindowMode():
+					return False, None, None, -1
 				# Check if this list is in the left sidebar (chat list area)
 				# vs the right side (message list area)
 				try:
@@ -1941,12 +2089,17 @@ def _findChatListFromWindow(handler):
 
 	Fallback when _findChatListFromCache fails (stale COM ref).
 	Finds List elements and picks the one in the left sidebar area.
+	In standalone ChatWindow mode there is no sidebar, so returns (None, None).
 	Returns (listElement, items) or (None, None).
 	"""
 	global _chatListSearchField
 	try:
 		hwnd = ctypes.windll.user32.GetForegroundWindow()
 		if not hwnd:
+			return None, None
+
+		# Standalone ChatWindow has no sidebar — no chat list to find
+		if _isChatWindowMode(hwnd):
 			return None, None
 
 		# Get window rect to identify sidebar area
@@ -2208,24 +2361,28 @@ def _queryAndSpeakUIAFocus():
 		# Only use copy-first for message list items.
 		if ct == 50007:  # ListItem
 			isMessageItem = False
-			try:
-				elRect = targetElement.CurrentBoundingRectangle
-				elLeft = int(elRect.left)
-				# Get the LINE window rect
-				lineHwnd = ctypes.windll.user32.GetForegroundWindow()
-				import ctypes.wintypes as _wt
-				wr = _wt.RECT()
-				ctypes.windll.user32.GetWindowRect(
-					lineHwnd, ctypes.byref(wr)
-				)
-				winWidth = int(wr.right - wr.left)
-				winLeft = int(wr.left)
-				# Message list items are in the right portion
-				# (element left edge > 35% of window width from left)
-				if winWidth > 0 and (elLeft - winLeft) > winWidth * 0.35:
-					isMessageItem = True
-			except Exception:
-				pass
+			# In standalone ChatWindow mode, all list items are message items
+			if _isChatWindowMode():
+				isMessageItem = True
+			else:
+				try:
+					elRect = targetElement.CurrentBoundingRectangle
+					elLeft = int(elRect.left)
+					# Get the LINE window rect
+					lineHwnd = ctypes.windll.user32.GetForegroundWindow()
+					import ctypes.wintypes as _wt
+					wr = _wt.RECT()
+					ctypes.windll.user32.GetWindowRect(
+						lineHwnd, ctypes.byref(wr)
+					)
+					winWidth = int(wr.right - wr.left)
+					winLeft = int(wr.left)
+					# Message list items are in the right portion
+					# (element left edge > 35% of window width from left)
+					if winWidth > 0 and (elLeft - winLeft) > winWidth * 0.35:
+						isMessageItem = True
+				except Exception:
+					pass
 			if isMessageItem:
 				log.info(
 					f"LINE UIA focus: ct={ct} (message ListItem), "
@@ -3321,9 +3478,14 @@ class AppModule(appModuleHandler.AppModule):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
 		VirtualWindow.initialize()
+		# Read and cache LINE installation info
+		self._lineVersion = _readLineVersion()
+		self._lineLanguage = _readLineLanguage()
 		log.info(
 			f"LINE AppModule loaded for process: {self.processID}, "
-			f"exe: {self.appName}"
+			f"exe: {self.appName}, "
+			f"lineVersion: {self._lineVersion}, "
+			f"lineLanguage: {self._lineLanguage}"
 		)
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
@@ -5819,6 +5981,38 @@ class AppModule(appModuleHandler.AppModule):
 		except Exception as e:
 			log.warning(f"LINE readChatRoomName error: {e}", exc_info=True)
 			ui.message(_("讀取聊天室名稱錯誤: {error}").format(error=e))
+
+	@script(
+		# Translators: Description of a script to report LINE version and window type
+		description=_("報告 LINE 版本與視窗類型"),
+		gesture="kb:NVDA+shift+v",
+		category="LINE Desktop",
+	)
+	def script_reportLineInfo(self, gesture):
+		"""Report LINE version, language, and current window type."""
+		parts = []
+		ver = self._lineVersion
+		if ver:
+			# Translators: Reported LINE version
+			parts.append(_("LINE 版本: {version}").format(version=ver))
+		else:
+			parts.append(_("LINE 版本: 未知"))
+		lang = self._lineLanguage
+		if lang:
+			parts.append(_("語言: {language}").format(language=lang))
+		winType = _classifyLineWindow()
+		typeNames = {
+			"allinone": _("主視窗（含側邊欄）"),
+			"chat": _("獨立聊天視窗"),
+			"unknown": _("未知視窗"),
+		}
+		# Translators: Reported LINE window type
+		parts.append(_("視窗類型: {type}").format(
+			type=typeNames.get(winType, winType)
+		))
+		msg = ", ".join(parts)
+		ui.message(msg)
+		log.info(f"LINE info: {msg}")
 
 	def _pollFileDialog(self):
 		"""Poll to detect when the file dialog closes, then resume addon.


### PR DESCRIPTION
## Summary

- **Read LINE version and language** from local INI files (`LINE.ini`, `installLang.ini`) at addon startup for debugging and diagnostic logging
- **Classify window type** (AllInOneWindow vs standalone ChatWindow) to properly handle UI layout differences
- **Fix sidebar heuristics** in ChatWindow mode where there is no chat list sidebar
- **Add diagnostic shortcut** (NVDA+Shift+V) to report LINE version, language, and window type

## Changes

### New Functions
- `_getLineDataDir()` — Locate LINE data directory
- `_readLineVersion()` — Extract version from LINE.ini
- `_readLineLanguage()` — Extract language from installLang.ini
- `_classifyLineWindow()` — Detect AllInOneWindow vs ChatWindow mode with caching
- `_isChatWindowMode()` — Helper to check if current window is ChatWindow

### Improved Logic
- `_isInChatListContext()` — Skip sidebar checks in ChatWindow mode
- `_findChatListFromWindow()` — Return early if in ChatWindow (no sidebar to search)
- `_queryAndSpeakUIAFocus()` — Treat all ListItems as message items in ChatWindow mode

### AppModule Updates
- Cache LINE version and language on init, log to debug output
- New script: `script_reportLineInfo()` (NVDA+Shift+V) to announce version, language, and window type

## Test Plan

- [x] Verify syntax with Python AST parser
- [x] Test version reading from LINE.ini (returns "26.1.0.3865")
- [x] Test language reading from installLang.ini (returns "zh-TW")
- [x] Confirm window classification detects AllInOneWindow (width ≥600px, multiple panes)
- [x] Test ChatWindow detection for standalone chat windows
- [x] Verify NVDA+Shift+V reports version and window type
- [x] Ensure sidebar heuristics are skipped in ChatWindow mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 為 LINE Desktop NVDA 附加元件新增 LINE 版本與語言的診斷性讀取（從本地 INI 檔案）、視窗類型分類（AllInOneWindow 與 ChatWindow），以及 NVDA+Shift+V 診斷快捷鍵。ChatWindow 模式下側邊欄相關啟發式判斷也會提前返回或改用更合適的邏輯。

主要變更摘要：
- 新增 `_getLineDataDir()`、`_readLineVersion()`、`_readLineLanguage()` 以讀取 LINE 安裝資訊作為診斷用途
- 新增 `_classifyLineWindow()` 以寬度啟發式 + UIA 窗格計數判斷視窗類型，並快取 2 秒
- 在 `_isInChatListContext`、`_findChatListFromWindow`、`_queryAndSpeakUIAFocus` 中加入 ChatWindow 模式早期返回路徑
- 在 `AppModule.__init__` 快取版本與語言，並新增 `script_reportLineInfo`（NVDA+Shift+V）

**尚待處理的問題：** 多個前次審查所提問題目前仍存在於程式碼中（`walker` 未使用、`TreeScope.Children` 深度不足、寬 ChatWindow 回退誤判、INI 區段名稱大小寫）。此外本次審查發現：當 `UIAHandler.handler` 為 `None` 或 `ElementFromHandle` 回傳 `None` 時，寬視窗的 `windowType` 會維持 `"unknown"` 而非回退到 `"allinone"`，導致 copy-first 讀取功能在邊緣情況下失效。

<h3>Confidence Score: 2/5</h3>

PR 的核心 ChatWindow 分類邏輯存在已知與新發現的準確性問題，視窗分類在特定情況下會退化，主要功能尚未穩定。

多個來自前次審查的 P1 問題（INI 區段大小寫、UIA 搜尋深度不足、寬 ChatWindow 回退誤判）仍存在於程式碼中未獲解決，加上本次新發現的 handler/rootEl 為 None 時 windowType 維持 unknown 的邏輯缺口，使視窗分類在邊緣情況下無法正確觸發 ChatWindow 路徑。

addon/appModules/line.py：特別關注 _classifyLineWindow() 中的 handler/rootEl None 路徑處理（第 135–153 行）

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 LINE 版本/語言偵測、ChatWindow 模式分類與診斷快捷鍵；視窗分類的 UIA None 路徑處理缺失，寬視窗可能被誤標為 "unknown" |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_classifyLineWindow 被呼叫] --> B{快取命中？}
    B -- 是 --> C[返回快取結果]
    B -- 否 --> D[GetWindowRect 取得 winWidth]
    D --> E{winWidth >= 600?}
    E -- 否 --> F[windowType = chat]
    E -- 是 --> G{UIAHandler.handler 非 None?}
    G -- 否 --> H[windowType 維持 unknown]
    G -- 是 --> I[ElementFromHandle 取得 rootEl]
    I --> J{rootEl 非 None?}
    J -- 否 --> K[windowType 維持 unknown]
    J -- 是 --> L[FindAll Pane 取得 paneCount]
    L --> M{paneCount >= 2?}
    M -- 是 --> N[windowType = allinone]
    M -- 否 --> O{winWidth >= 700?}
    O -- 是 --> P[windowType = allinone]
    O -- 否 --> Q[windowType = chat]
    H --> R[快取結果]
    K --> R
    F --> R
    N --> R
    P --> R
    Q --> R
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A135-153%0A**%60handler%60%20%E6%88%96%20%60rootEl%60%20%E7%82%BA%20%60None%60%20%E6%99%82%E5%AF%AC%E8%A6%96%E7%AA%97%E8%A2%AB%E8%AA%A4%E5%88%86%E9%A1%9E%E7%82%BA%20%60%22unknown%22%60**%0A%0A%E7%95%B6%20%60UIAHandler.handler%60%20%E7%82%BA%20%60None%60%EF%BC%88UIA%20%E5%B0%9A%E6%9C%AA%E5%B0%B1%E7%B7%92%EF%BC%89%E6%88%96%20%60ElementFromHandle%60%20%E8%BF%94%E5%9B%9E%20%60None%60%20%E6%99%82%EF%BC%8C%E5%B0%8D%E6%87%89%E7%9A%84%20%60if%60%20%E5%88%86%E6%94%AF%E7%9B%B4%E6%8E%A5%E8%A2%AB%E8%B7%B3%E9%81%8E%EF%BC%8C%E4%B8%8D%E6%9C%83%E8%A7%B8%E7%99%BC%20%60except%20Exception%60%EF%BC%8C%E5%9B%A0%E6%AD%A4%20%60windowType%60%20%E7%B6%AD%E6%8C%81%E5%88%9D%E5%A7%8B%E5%80%BC%20%60%22unknown%22%60%E3%80%82%0A%0A%E5%B0%8D%E6%96%BC%E5%AF%AC%E5%BA%A6%20%E2%89%A5%20600px%20%E7%9A%84%E8%A6%96%E7%AA%97%EF%BC%8C%E9%96%8B%E7%99%BC%E8%80%85%E7%9A%84%E6%84%8F%E5%9C%96%E6%98%AF%E5%9B%9E%E9%80%80%E5%88%B0%20%60%22allinone%22%60%EF%BC%88%E5%A6%82%20%60except%60%20%E5%88%86%E6%94%AF%E7%9A%84%E6%B3%A8%E9%87%8B%E6%89%80%E7%A4%BA%EF%BC%89%E3%80%82%E4%BD%86%20%60handler%20is%20None%60%20%E6%88%96%20%60rootEl%20is%20None%60%20%E9%80%99%E5%85%A9%E5%80%8B%E8%B7%AF%E5%BE%91%E7%B9%9E%E9%81%8E%E4%BA%86%20%60except%60%EF%BC%8C%E7%9B%B4%E6%8E%A5%E8%AE%93%20%60windowType%20%3D%20%22unknown%22%60%20%E8%A2%AB%E5%BF%AB%E5%8F%96%E3%80%82%E5%BE%8C%E7%BA%8C%20%60_isChatWindowMode%28%29%60%20%E5%9B%9E%E5%82%B3%20%60False%60%EF%BC%8C%E5%B0%8E%E8%87%B4%20%60_queryAndSpeakUIAFocus%60%20%E4%B8%AD%20ChatWindow%20%E7%9A%84%E8%A8%8A%E6%81%AF%E9%A0%85%E7%9B%AE%E5%9B%9E%E9%80%80%E5%88%B0%E4%BD%8D%E7%BD%AE%E5%83%8F%E7%B4%A0%E5%88%A4%E6%96%B7%EF%BC%8C%60isMessageItem%60%20%E6%B0%B8%E9%81%A0%E7%82%BA%20%60False%60%EF%BC%8Ccopy-first%20%E8%AE%80%E5%8F%96%E5%8A%9F%E8%83%BD%E5%A4%B1%E6%95%88%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E6%98%8E%E7%A2%BA%E8%99%95%E7%90%86%20%60None%60%20%E8%B7%AF%E5%BE%91%EF%BC%9A%0A%0A%60%60%60python%0Ahandler%20%3D%20UIAHandler.handler%0Aif%20handler%3A%0A%20%20%20%20rootCond%20%3D%20handler.clientObject.CreatePropertyCondition%28%0A%20%20%20%20%20%20%20%2030003%2C%2050033%20%20%23%20ControlType%20%3D%3D%20Pane%0A%20%20%20%20%29%0A%20%20%20%20rootEl%20%3D%20handler.clientObject.ElementFromHandle%28hwnd%29%0A%20%20%20%20if%20rootEl%3A%0A%20%20%20%20%20%20%20%20panes%20%3D%20rootEl.FindAll%282%2C%20rootCond%29%0A%20%20%20%20%20%20%20%20paneCount%20%3D%20panes.Length%20if%20panes%20else%200%0A%20%20%20%20%20%20%20%20if%20paneCount%20%3E%3D%202%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20windowType%20%3D%20%22allinone%22%0A%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20windowType%20%3D%20%22allinone%22%20if%20winWidth%20%3E%3D%20700%20else%20%22chat%22%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20windowType%20%3D%20%22allinone%22%20if%20winWidth%20%3E%3D%20700%20else%20%22chat%22%0Aelse%3A%0A%20%20%20%20windowType%20%3D%20%22allinone%22%0A%60%60%60%0A%0A&repo=keyang556%2Flinedesktopnvda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Famazing-cray%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Famazing-cray%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A135-153%0A**%60handler%60%20%E6%88%96%20%60rootEl%60%20%E7%82%BA%20%60None%60%20%E6%99%82%E5%AF%AC%E8%A6%96%E7%AA%97%E8%A2%AB%E8%AA%A4%E5%88%86%E9%A1%9E%E7%82%BA%20%60%22unknown%22%60**%0A%0A%E7%95%B6%20%60UIAHandler.handler%60%20%E7%82%BA%20%60None%60%EF%BC%88UIA%20%E5%B0%9A%E6%9C%AA%E5%B0%B1%E7%B7%92%EF%BC%89%E6%88%96%20%60ElementFromHandle%60%20%E8%BF%94%E5%9B%9E%20%60None%60%20%E6%99%82%EF%BC%8C%E5%B0%8D%E6%87%89%E7%9A%84%20%60if%60%20%E5%88%86%E6%94%AF%E7%9B%B4%E6%8E%A5%E8%A2%AB%E8%B7%B3%E9%81%8E%EF%BC%8C%E4%B8%8D%E6%9C%83%E8%A7%B8%E7%99%BC%20%60except%20Exception%60%EF%BC%8C%E5%9B%A0%E6%AD%A4%20%60windowType%60%20%E7%B6%AD%E6%8C%81%E5%88%9D%E5%A7%8B%E5%80%BC%20%60%22unknown%22%60%E3%80%82%0A%0A%E5%B0%8D%E6%96%BC%E5%AF%AC%E5%BA%A6%20%E2%89%A5%20600px%20%E7%9A%84%E8%A6%96%E7%AA%97%EF%BC%8C%E9%96%8B%E7%99%BC%E8%80%85%E7%9A%84%E6%84%8F%E5%9C%96%E6%98%AF%E5%9B%9E%E9%80%80%E5%88%B0%20%60%22allinone%22%60%EF%BC%88%E5%A6%82%20%60except%60%20%E5%88%86%E6%94%AF%E7%9A%84%E6%B3%A8%E9%87%8B%E6%89%80%E7%A4%BA%EF%BC%89%E3%80%82%E4%BD%86%20%60handler%20is%20None%60%20%E6%88%96%20%60rootEl%20is%20None%60%20%E9%80%99%E5%85%A9%E5%80%8B%E8%B7%AF%E5%BE%91%E7%B9%9E%E9%81%8E%E4%BA%86%20%60except%60%EF%BC%8C%E7%9B%B4%E6%8E%A5%E8%AE%93%20%60windowType%20%3D%20%22unknown%22%60%20%E8%A2%AB%E5%BF%AB%E5%8F%96%E3%80%82%E5%BE%8C%E7%BA%8C%20%60_isChatWindowMode%28%29%60%20%E5%9B%9E%E5%82%B3%20%60False%60%EF%BC%8C%E5%B0%8E%E8%87%B4%20%60_queryAndSpeakUIAFocus%60%20%E4%B8%AD%20ChatWindow%20%E7%9A%84%E8%A8%8A%E6%81%AF%E9%A0%85%E7%9B%AE%E5%9B%9E%E9%80%80%E5%88%B0%E4%BD%8D%E7%BD%AE%E5%83%8F%E7%B4%A0%E5%88%A4%E6%96%B7%EF%BC%8C%60isMessageItem%60%20%E6%B0%B8%E9%81%A0%E7%82%BA%20%60False%60%EF%BC%8Ccopy-first%20%E8%AE%80%E5%8F%96%E5%8A%9F%E8%83%BD%E5%A4%B1%E6%95%88%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E6%98%8E%E7%A2%BA%E8%99%95%E7%90%86%20%60None%60%20%E8%B7%AF%E5%BE%91%EF%BC%9A%0A%0A%60%60%60python%0Ahandler%20%3D%20UIAHandler.handler%0Aif%20handler%3A%0A%20%20%20%20rootCond%20%3D%20handler.clientObject.CreatePropertyCondition%28%0A%20%20%20%20%20%20%20%2030003%2C%2050033%20%20%23%20ControlType%20%3D%3D%20Pane%0A%20%20%20%20%29%0A%20%20%20%20rootEl%20%3D%20handler.clientObject.ElementFromHandle%28hwnd%29%0A%20%20%20%20if%20rootEl%3A%0A%20%20%20%20%20%20%20%20panes%20%3D%20rootEl.FindAll%282%2C%20rootCond%29%0A%20%20%20%20%20%20%20%20paneCount%20%3D%20panes.Length%20if%20panes%20else%200%0A%20%20%20%20%20%20%20%20if%20paneCount%20%3E%3D%202%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20windowType%20%3D%20%22allinone%22%0A%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20windowType%20%3D%20%22allinone%22%20if%20winWidth%20%3E%3D%20700%20else%20%22chat%22%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20windowType%20%3D%20%22allinone%22%20if%20winWidth%20%3E%3D%20700%20else%20%22chat%22%0Aelse%3A%0A%20%20%20%20windowType%20%3D%20%22allinone%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 135-153

Comment:
**`handler` 或 `rootEl` 為 `None` 時寬視窗被誤分類為 `"unknown"`**

當 `UIAHandler.handler` 為 `None`（UIA 尚未就緒）或 `ElementFromHandle` 返回 `None` 時，對應的 `if` 分支直接被跳過，不會觸發 `except Exception`，因此 `windowType` 維持初始值 `"unknown"`。

對於寬度 ≥ 600px 的視窗，開發者的意圖是回退到 `"allinone"`（如 `except` 分支的注釋所示）。但 `handler is None` 或 `rootEl is None` 這兩個路徑繞過了 `except`，直接讓 `windowType = "unknown"` 被快取。後續 `_isChatWindowMode()` 回傳 `False`，導致 `_queryAndSpeakUIAFocus` 中 ChatWindow 的訊息項目回退到位置像素判斷，`isMessageItem` 永遠為 `False`，copy-first 讀取功能失效。

建議明確處理 `None` 路徑：

```python
handler = UIAHandler.handler
if handler:
    rootCond = handler.clientObject.CreatePropertyCondition(
        30003, 50033  # ControlType == Pane
    )
    rootEl = handler.clientObject.ElementFromHandle(hwnd)
    if rootEl:
        panes = rootEl.FindAll(2, rootCond)
        paneCount = panes.Length if panes else 0
        if paneCount >= 2:
            windowType = "allinone"
        else:
            windowType = "allinone" if winWidth >= 700 else "chat"
    else:
        windowType = "allinone" if winWidth >= 700 else "chat"
else:
    windowType = "allinone"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["Add LINE version detection and ChatWindo..."](https://github.com/keyang556/linedesktopnvda/commit/e0c07743473f33ba4e0689d15c3d1d8885feb9e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28118878)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->