### PR TITLE
Add QT_ACCESSIBILITY=1 toggle for Qt6 accessibility support

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -6084,12 +6084,6 @@ class AppModule(appModuleHandler.AppModule):
 		ui.message(msg)
 		log.info(f"LINE info: {msg}")
 
-	@script(
-		# Translators: Description of a script to toggle Qt accessibility env var
-		description=_("切換 Qt 無障礙環境變數"),
-		gesture="kb:NVDA+shift+a",
-		category="LINE Desktop",
-	)
 	def script_toggleQtAccessible(self, gesture):
 		"""Toggle QT_ACCESSIBILITY=1 user environment variable."""
 		currentlySet = _isQtAccessibleSet()

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -24,6 +24,7 @@ import comtypes
 import re
 import time
 import configparser
+import winreg
 from ._virtualWindow import VirtualWindow
 import addonHandler
 
@@ -81,6 +82,69 @@ def _readLineLanguage():
 		return parser.get("General", "installLang", fallback=None)
 	except Exception:
 		return None
+
+
+# ---------------------------------------------------------------------------
+# Qt accessibility environment variable management
+# ---------------------------------------------------------------------------
+
+_QT_ACCESSIBILITY_ENV_NAME = "QT_ACCESSIBILITY"
+_HWND_BROADCAST = 0xFFFF
+_WM_SETTINGCHANGE = 0x001A
+_SMTO_ABORTIFHUNG = 0x0002
+
+
+def _isQtAccessibleSet():
+	"""Check if QT_ACCESSIBILITY=1 is set in user environment variables.
+
+	Returns True if the variable is set to '1', False otherwise.
+	"""
+	try:
+		with winreg.OpenKey(
+			winreg.HKEY_CURRENT_USER, "Environment", 0, winreg.KEY_READ
+		) as key:
+			value, _ = winreg.QueryValueEx(key, _QT_ACCESSIBILITY_ENV_NAME)
+			return str(value) == "1"
+	except FileNotFoundError:
+		return False
+	except Exception:
+		log.debugWarning("Failed to read QT_ACCESSIBILITY from registry", exc_info=True)
+		return False
+
+
+def _setQtAccessible(enable=True):
+	"""Set or remove QT_ACCESSIBILITY in user environment variables.
+
+	Writes to HKCU\\Environment so the setting persists across reboots.
+	Broadcasts WM_SETTINGCHANGE so new processes pick up the change.
+	Returns True on success, False on failure.
+	"""
+	try:
+		with winreg.OpenKey(
+			winreg.HKEY_CURRENT_USER, "Environment", 0,
+			winreg.KEY_SET_VALUE | winreg.KEY_READ
+		) as key:
+			if enable:
+				winreg.SetValueEx(
+					key, _QT_ACCESSIBILITY_ENV_NAME, 0,
+					winreg.REG_SZ, "1"
+				)
+				log.info("QT_ACCESSIBILITY=1 set in user environment")
+			else:
+				try:
+					winreg.DeleteValue(key, _QT_ACCESSIBILITY_ENV_NAME)
+					log.info("QT_ACCESSIBILITY removed from user environment")
+				except FileNotFoundError:
+					pass
+		# Broadcast environment change to all windows
+		ctypes.windll.user32.SendMessageTimeoutW(
+			_HWND_BROADCAST, _WM_SETTINGCHANGE, 0,
+			"Environment", _SMTO_ABORTIFHUNG, 5000, None
+		)
+		return True
+	except Exception:
+		log.warning("Failed to set QT_ACCESSIBILITY in registry", exc_info=True)
+		return False
 
 
 # Window type classification —
@@ -3481,11 +3545,13 @@ class AppModule(appModuleHandler.AppModule):
 		# Read and cache LINE installation info
 		self._lineVersion = _readLineVersion()
 		self._lineLanguage = _readLineLanguage()
+		self._qtAccessibleSet = _isQtAccessibleSet()
 		log.info(
 			f"LINE AppModule loaded for process: {self.processID}, "
 			f"exe: {self.appName}, "
 			f"lineVersion: {self._lineVersion}, "
-			f"lineLanguage: {self._lineLanguage}"
+			f"lineLanguage: {self._lineLanguage}, "
+			f"qtAccessible: {self._qtAccessibleSet}"
 		)
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
@@ -6010,9 +6076,33 @@ class AppModule(appModuleHandler.AppModule):
 		parts.append(_("視窗類型: {type}").format(
 			type=typeNames.get(winType, winType)
 		))
+		qtA11y = _isQtAccessibleSet()
+		parts.append(
+			_("Qt 無障礙: 已啟用") if qtA11y else _("Qt 無障礙: 未啟用")
+		)
 		msg = ", ".join(parts)
 		ui.message(msg)
 		log.info(f"LINE info: {msg}")
+
+	@script(
+		# Translators: Description of a script to toggle Qt accessibility env var
+		description=_("切換 Qt 無障礙環境變數"),
+		gesture="kb:NVDA+shift+a",
+		category="LINE Desktop",
+	)
+	def script_toggleQtAccessible(self, gesture):
+		"""Toggle QT_ACCESSIBILITY=1 user environment variable."""
+		currentlySet = _isQtAccessibleSet()
+		if currentlySet:
+			if _setQtAccessible(False):
+				ui.message(_("已移除 QT_ACCESSIBILITY 環境變數，重啟 LINE 後生效"))
+			else:
+				ui.message(_("移除 QT_ACCESSIBILITY 環境變數失敗"))
+		else:
+			if _setQtAccessible(True):
+				ui.message(_("已設定 QT_ACCESSIBILITY=1，重啟 LINE 後生效"))
+			else:
+				ui.message(_("設定 QT_ACCESSIBILITY 環境變數失敗"))
 
 	def _pollFileDialog(self):
 		"""Poll to detect when the file dialog closes, then resume addon.

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -204,7 +204,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self._qtAccessibleItem = self._lineSubMenu.Append(
 				wx.ID_ANY,
 				# Translators: Menu item for toggling Qt accessibility env var
-				_("切換 Qt 無障礙環境變數(&Q)") + "\tNVDA+Shift+A",
+				_("切換 Qt 無障礙環境變數(&Q)"),
 			)
 
 			# Bind events

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -8,9 +8,63 @@ from scriptHandler import script
 from logHandler import log
 import gui
 import wx
+import winreg
+import ctypes
 import addonHandler
 
 addonHandler.initTranslation()
+
+
+# ---------------------------------------------------------------------------
+# Qt accessibility environment variable helpers (duplicated from line.py
+# so the global plugin can toggle the setting even when LINE is not running)
+# ---------------------------------------------------------------------------
+
+_QT_ACCESSIBILITY_ENV_NAME = "QT_ACCESSIBILITY"
+_HWND_BROADCAST = 0xFFFF
+_WM_SETTINGCHANGE = 0x001A
+_SMTO_ABORTIFHUNG = 0x0002
+
+
+def _isQtAccessibleSet():
+	"""Check if QT_ACCESSIBILITY=1 is set in user environment variables."""
+	try:
+		with winreg.OpenKey(
+			winreg.HKEY_CURRENT_USER, "Environment", 0, winreg.KEY_READ
+		) as key:
+			value, _ = winreg.QueryValueEx(key, _QT_ACCESSIBILITY_ENV_NAME)
+			return str(value) == "1"
+	except FileNotFoundError:
+		return False
+	except Exception:
+		return False
+
+
+def _setQtAccessible(enable=True):
+	"""Set or remove QT_ACCESSIBILITY in user environment variables."""
+	try:
+		with winreg.OpenKey(
+			winreg.HKEY_CURRENT_USER, "Environment", 0,
+			winreg.KEY_SET_VALUE | winreg.KEY_READ
+		) as key:
+			if enable:
+				winreg.SetValueEx(
+					key, _QT_ACCESSIBILITY_ENV_NAME, 0,
+					winreg.REG_SZ, "1"
+				)
+			else:
+				try:
+					winreg.DeleteValue(key, _QT_ACCESSIBILITY_ENV_NAME)
+				except FileNotFoundError:
+					pass
+		ctypes.windll.user32.SendMessageTimeoutW(
+			_HWND_BROADCAST, _WM_SETTINGCHANGE, 0,
+			"Environment", _SMTO_ABORTIFHUNG, 5000, None
+		)
+		return True
+	except Exception:
+		log.warning("Failed to set QT_ACCESSIBILITY in registry", exc_info=True)
+		return False
 
 
 def _getLineAppModule():
@@ -144,6 +198,15 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				_("跳到通話視窗(&F)") + "\tNVDA+Windows+F",
 			)
 
+			self._lineSubMenu.AppendSeparator()
+
+			# ── Settings ──
+			self._qtAccessibleItem = self._lineSubMenu.Append(
+				wx.ID_ANY,
+				# Translators: Menu item for toggling Qt accessibility env var
+				_("切換 Qt 無障礙環境變數(&Q)") + "\tNVDA+Shift+A",
+			)
+
 			# Bind events
 			gui.mainFrame.sysTrayIcon.Bind(
 				wx.EVT_MENU, self._onAllChats, self._allChatsItem
@@ -186,6 +249,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			)
 			gui.mainFrame.sysTrayIcon.Bind(
 				wx.EVT_MENU, self._onFocusCallWindow, self._focusCallItem
+			)
+			gui.mainFrame.sysTrayIcon.Bind(
+				wx.EVT_MENU, self._onToggleQtAccessible, self._qtAccessibleItem
 			)
 
 			# Add the submenu to NVDA's Tools menu
@@ -428,6 +494,28 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		except Exception as e:
 			log.warning(f"LINE focusCallWindow error: {e}", exc_info=True)
 			ui.message(_("跳到通話視窗功能錯誤: {error}").format(error=e))
+
+	def _onToggleQtAccessible(self, evt):
+		wx.CallAfter(self._doToggleQtAccessible)
+
+	def _doToggleQtAccessible(self):
+		import ui
+		lineApp = _getLineAppModule()
+		if lineApp and hasattr(lineApp, 'script_toggleQtAccessible'):
+			lineApp.script_toggleQtAccessible(None)
+			return
+		# LINE not running — toggle the env var directly
+		currentlySet = _isQtAccessibleSet()
+		if currentlySet:
+			if _setQtAccessible(False):
+				ui.message(_("已移除 QT_ACCESSIBILITY 環境變數，重啟 LINE 後生效"))
+			else:
+				ui.message(_("移除 QT_ACCESSIBILITY 環境變數失敗"))
+		else:
+			if _setQtAccessible(True):
+				ui.message(_("已設定 QT_ACCESSIBILITY=1，重啟 LINE 後生效"))
+			else:
+				ui.message(_("設定 QT_ACCESSIBILITY 環境變數失敗"))
 
 	def terminate(self, *args, **kwargs):
 		self._removeToolsMenu()


### PR DESCRIPTION
## Summary
Adds a persistent user environment variable toggle for `QT_ACCESSIBILITY=1` to improve Qt6 accessibility support in LINE Desktop. The setting is stored in the Windows registry (`HKCU\Environment`) and persists across reboots.

## Features
- **Menu item**: NVDA Tools > LINE Desktop > 切換 Qt 無障礙環境變數
- **Status reporting**: NVDA+Shift+V now includes Qt accessibility status
- **Works offline**: Toggle can be set even when LINE is not running
- **Auto-broadcast**: Changes are broadcast via `WM_SETTINGCHANGE` to notify running processes

## Implementation
- Reads/writes `HKCU\Environment\QT_ACCESSIBILITY` via Windows registry
- Includes helper functions in both `line.py` and `globalPlugins/lineDesktopHelper.py`
- User is informed that LINE needs to be restarted for changes to take effect
- AppModule logs Qt accessibility status at startup

## Testing
- Modified files pass Python syntax validation
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 新增了 `QT_ACCESSIBILITY=1` 使用者環境變數的切換功能，以改善 LINE Desktop 在 Qt6 下的輔助功能支援。實作方式為直接讀寫 Windows 登錄機碼 `HKCU\\Environment`，並透過 `WM_SETTINGCHANGE` 廣播通知所有執行中的程序，設定在重開機後持續有效。

**主要變更：**
- `line.py`：新增 `_isQtAccessibleSet` / `_setQtAccessible` 輔助函式、`script_toggleQtAccessible` 腳本，並在 `script_reportLineInfo`（NVDA+Shift+V）的狀態報告中加入 Qt 無障礙狀態
- `lineDesktopHelper.py`：新增對應的選單項目（「切換 Qt 無障礙環境變數」）及事件處理邏輯，LINE 未執行時仍可直接操作；輔助函式與 `line.py` 重複（註解中已坦承）

**發現的問題：**
- `script_toggleQtAccessible` 在 `line.py` 中缺少 `@script` 裝飾器與 `gesture` 宣告，導致 PR 說明所列的 NVDA+Shift+A 鍵盤快捷鍵實際上不會被 NVDA 綁定，無法透過鍵盤觸發此功能。

<h3>Confidence Score: 3/5</h3>

PR 存在一個明確的功能缺失：`@script` 裝飾器遺漏使鍵盤快捷鍵完全無法運作，需在合併前修正。

核心功能（選單項目切換）可正常運作，登錄機碼讀寫邏輯無明顯錯誤，但 PR 說明宣稱的 NVDA+Shift+A 快捷鍵因缺少 `@script` 裝飾器而完全失效，屬於功能性缺失，需在合併前補上裝飾器。加上先前評論中尚未修正的問題（CreateKeyEx、靜默例外、重複程式碼），整體還需多一輪修正。

`addon/appModules/line.py`：`script_toggleQtAccessible` 缺少 `@script` 裝飾器與 gesture 宣告。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 Qt 無障礙環境變數的讀寫輔助函式與 `script_toggleQtAccessible`，但後者缺少 `@script` 裝飾器，導致 PR 說明中宣稱的 NVDA+Shift+A 快捷鍵無法運作。 |
| addon/globalPlugins/lineDesktopHelper.py | 新增 Qt 無障礙選單項目與事件處理函式，當 LINE 執行中時委派至 AppModule，未執行時直接操作登錄機碼，邏輯正確；`_isQtAccessibleSet` 的最終 except 未記錄日誌（已於先前評論中提及）。 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[使用者觸發切換] --> B{觸發來源}
    B -->|選單項目| C[GlobalPlugin._onToggleQtAccessible]
    B -->|鍵盤快捷鍵| D[❌ @script 裝飾器缺失\nNVDA+Shift+A 無效]
    C --> E[wx.CallAfter → _doToggleQtAccessible]
    E --> F{LINE 是否執行中？}
    F -->|是| G[委派至 AppModule.script_toggleQtAccessible]
    F -->|否| H[直接呼叫 GlobalPlugin._isQtAccessibleSet / _setQtAccessible]
    G --> I[_isQtAccessibleSet → HKCU\\Environment]
    G --> J[_setQtAccessible → winreg.OpenKey / SetValueEx / DeleteValue]
    H --> I
    H --> J
    J --> K[SendMessageTimeoutW WM_SETTINGCHANGE 廣播]
    K --> L[ui.message 通知使用者]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A6087-6099%0A**%E7%BC%BA%E5%B0%91%20%60%40script%60%20%E8%A3%9D%E9%A3%BE%E5%99%A8%EF%BC%8C%E5%BF%AB%E6%8D%B7%E9%8D%B5%E7%84%A1%E6%B3%95%E9%81%8B%E4%BD%9C**%0A%0A%60script_toggleQtAccessible%60%20%E9%9B%96%E7%84%B6%E9%81%B5%E5%BE%AA%20NVDA%20%E7%9A%84%20%60script_*%60%20%E5%91%BD%E5%90%8D%E6%85%A3%E4%BE%8B%EF%BC%8C%E4%BD%86%E5%AE%8C%E5%85%A8%E7%BC%BA%E5%B0%91%20%60%40script%60%20%E8%A3%9D%E9%A3%BE%E5%99%A8%E8%88%87%20%60gesture%60%20%E5%AE%A3%E5%91%8A%E3%80%82%E5%A6%82%E6%AD%A4%E4%B8%80%E4%BE%86%EF%BC%8CNVDA%20%E4%B8%8D%E6%9C%83%E5%B0%87%E4%BB%BB%E4%BD%95%E9%8D%B5%E7%9B%A4%E6%89%8B%E5%8B%A2%E7%B6%81%E5%AE%9A%E5%88%B0%E6%AD%A4%E5%87%BD%E5%BC%8F%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E7%84%A1%E8%AB%96%E6%8C%89%E4%B8%8B%20%60NVDA%2BShift%2BA%60%20%E6%88%96%E5%85%B6%E4%BB%96%E4%BB%BB%E4%BD%95%E7%B5%84%E5%90%88%E9%8D%B5%EF%BC%8C%E9%83%BD%E4%B8%8D%E6%9C%83%E6%9C%89%E4%BB%BB%E4%BD%95%E5%8F%8D%E6%87%89%E3%80%82%0A%0APR%20%E8%AA%AA%E6%98%8E%E6%98%8E%E7%A2%BA%E5%88%97%E5%87%BA%E3%80%8C**Keyboard%20shortcut%3A%20NVDA%2BShift%2BA%20to%20toggle%20the%20setting**%E3%80%8D%EF%BC%8C%E4%BD%86%E6%90%9C%E5%B0%8B%E6%95%B4%E5%80%8B%E7%A8%8B%E5%BC%8F%E7%A2%BC%E5%BA%AB%E7%A2%BA%E8%AA%8D%E6%AD%A4%E6%89%8B%E5%8B%A2%E4%B8%A6%E6%9C%AA%E8%A2%AB%E5%AE%A3%E5%91%8A%E6%96%BC%E4%BB%BB%E4%BD%95%E5%9C%B0%E6%96%B9%E3%80%82%0A%0A%E5%B0%8D%E7%85%A7%E5%90%8C%E4%B8%80%E6%AA%94%E6%A1%88%E5%85%A7%E5%85%B6%E4%BB%96%E8%85%B3%E6%9C%AC%EF%BC%88%E5%A6%82%20%60script_reportLineInfo%60%EF%BC%89%EF%BC%8C%E6%AD%A3%E7%A2%BA%E7%9A%84%E5%AF%AB%E6%B3%95%E6%87%89%E7%82%BA%EF%BC%9A%0A%0A%60%60%60suggestion%0A%09%40script%28%0A%09%09%23%20Translators%3A%20Description%20of%20a%20script%20to%20toggle%20Qt%20accessibility%20env%20var%0A%09%09description%3D_%28%22%E5%88%87%E6%8F%9B%20Qt%20%E7%84%A1%E9%9A%9C%E7%A4%99%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%22%29%2C%0A%09%09gesture%3D%22kb%3ANVDA%2Bshift%2Ba%22%2C%0A%09%09category%3D%22LINE%20Desktop%22%2C%0A%09%29%0A%09def%20script_toggleQtAccessible%28self%2C%20gesture%29%3A%0A%09%09%22%22%22Toggle%20QT_ACCESSIBILITY%3D1%20user%20environment%20variable.%22%22%22%0A%09%09currentlySet%20%3D%20_isQtAccessibleSet%28%29%0A%09%09if%20currentlySet%3A%0A%09%09%09if%20_setQtAccessible%28False%29%3A%0A%09%09%09%09ui.message%28_%28%22%E5%B7%B2%E7%A7%BB%E9%99%A4%20QT_ACCESSIBILITY%20%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%EF%BC%8C%E9%87%8D%E5%95%9F%20LINE%20%E5%BE%8C%E7%94%9F%E6%95%88%22%29%29%0A%09%09%09else%3A%0A%09%09%09%09ui.message%28_%28%22%E7%A7%BB%E9%99%A4%20QT_ACCESSIBILITY%20%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%E5%A4%B1%E6%95%97%22%29%29%0A%09%09else%3A%0A%09%09%09if%20_setQtAccessible%28True%29%3A%0A%09%09%09%09ui.message%28_%28%22%E5%B7%B2%E8%A8%AD%E5%AE%9A%20QT_ACCESSIBILITY%3D1%EF%BC%8C%E9%87%8D%E5%95%9F%20LINE%20%E5%BE%8C%E7%94%9F%E6%95%88%22%29%29%0A%09%09%09else%3A%0A%09%09%09%09ui.message%28_%28%22%E8%A8%AD%E5%AE%9A%20QT_ACCESSIBILITY%20%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%E5%A4%B1%E6%95%97%22%29%29%0A%60%60%60%0A%0A%E8%A3%9C%E4%B8%8A%E8%A3%9D%E9%A3%BE%E5%99%A8%E5%BE%8C%EF%BC%8C%E4%B9%9F%E5%BB%BA%E8%AD%B0%E5%9C%A8%E9%81%B8%E5%96%AE%E9%A0%85%E7%9B%AE%E6%A8%99%E7%B1%A4%E4%B8%AD%E5%8A%A0%E5%85%A5%E5%BF%AB%E6%8D%B7%E9%8D%B5%E6%8F%90%E7%A4%BA%EF%BC%88%60%2B%20%22%5CtNVDA%2BShift%2BA%22%60%EF%BC%89%EF%BC%8C%E8%88%87%E5%85%B6%E4%BB%96%E9%81%B8%E5%96%AE%E9%A0%85%E7%9B%AE%E4%BF%9D%E6%8C%81%E4%B8%80%E8%87%B4%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Ffriendly-leakey%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Ffriendly-leakey%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A6087-6099%0A**%E7%BC%BA%E5%B0%91%20%60%40script%60%20%E8%A3%9D%E9%A3%BE%E5%99%A8%EF%BC%8C%E5%BF%AB%E6%8D%B7%E9%8D%B5%E7%84%A1%E6%B3%95%E9%81%8B%E4%BD%9C**%0A%0A%60script_toggleQtAccessible%60%20%E9%9B%96%E7%84%B6%E9%81%B5%E5%BE%AA%20NVDA%20%E7%9A%84%20%60script_*%60%20%E5%91%BD%E5%90%8D%E6%85%A3%E4%BE%8B%EF%BC%8C%E4%BD%86%E5%AE%8C%E5%85%A8%E7%BC%BA%E5%B0%91%20%60%40script%60%20%E8%A3%9D%E9%A3%BE%E5%99%A8%E8%88%87%20%60gesture%60%20%E5%AE%A3%E5%91%8A%E3%80%82%E5%A6%82%E6%AD%A4%E4%B8%80%E4%BE%86%EF%BC%8CNVDA%20%E4%B8%8D%E6%9C%83%E5%B0%87%E4%BB%BB%E4%BD%95%E9%8D%B5%E7%9B%A4%E6%89%8B%E5%8B%A2%E7%B6%81%E5%AE%9A%E5%88%B0%E6%AD%A4%E5%87%BD%E5%BC%8F%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E7%84%A1%E8%AB%96%E6%8C%89%E4%B8%8B%20%60NVDA%2BShift%2BA%60%20%E6%88%96%E5%85%B6%E4%BB%96%E4%BB%BB%E4%BD%95%E7%B5%84%E5%90%88%E9%8D%B5%EF%BC%8C%E9%83%BD%E4%B8%8D%E6%9C%83%E6%9C%89%E4%BB%BB%E4%BD%95%E5%8F%8D%E6%87%89%E3%80%82%0A%0APR%20%E8%AA%AA%E6%98%8E%E6%98%8E%E7%A2%BA%E5%88%97%E5%87%BA%E3%80%8C**Keyboard%20shortcut%3A%20NVDA%2BShift%2BA%20to%20toggle%20the%20setting**%E3%80%8D%EF%BC%8C%E4%BD%86%E6%90%9C%E5%B0%8B%E6%95%B4%E5%80%8B%E7%A8%8B%E5%BC%8F%E7%A2%BC%E5%BA%AB%E7%A2%BA%E8%AA%8D%E6%AD%A4%E6%89%8B%E5%8B%A2%E4%B8%A6%E6%9C%AA%E8%A2%AB%E5%AE%A3%E5%91%8A%E6%96%BC%E4%BB%BB%E4%BD%95%E5%9C%B0%E6%96%B9%E3%80%82%0A%0A%E5%B0%8D%E7%85%A7%E5%90%8C%E4%B8%80%E6%AA%94%E6%A1%88%E5%85%A7%E5%85%B6%E4%BB%96%E8%85%B3%E6%9C%AC%EF%BC%88%E5%A6%82%20%60script_reportLineInfo%60%EF%BC%89%EF%BC%8C%E6%AD%A3%E7%A2%BA%E7%9A%84%E5%AF%AB%E6%B3%95%E6%87%89%E7%82%BA%EF%BC%9A%0A%0A%60%60%60suggestion%0A%09%40script%28%0A%09%09%23%20Translators%3A%20Description%20of%20a%20script%20to%20toggle%20Qt%20accessibility%20env%20var%0A%09%09description%3D_%28%22%E5%88%87%E6%8F%9B%20Qt%20%E7%84%A1%E9%9A%9C%E7%A4%99%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%22%29%2C%0A%09%09gesture%3D%22kb%3ANVDA%2Bshift%2Ba%22%2C%0A%09%09category%3D%22LINE%20Desktop%22%2C%0A%09%29%0A%09def%20script_toggleQtAccessible%28self%2C%20gesture%29%3A%0A%09%09%22%22%22Toggle%20QT_ACCESSIBILITY%3D1%20user%20environment%20variable.%22%22%22%0A%09%09currentlySet%20%3D%20_isQtAccessibleSet%28%29%0A%09%09if%20currentlySet%3A%0A%09%09%09if%20_setQtAccessible%28False%29%3A%0A%09%09%09%09ui.message%28_%28%22%E5%B7%B2%E7%A7%BB%E9%99%A4%20QT_ACCESSIBILITY%20%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%EF%BC%8C%E9%87%8D%E5%95%9F%20LINE%20%E5%BE%8C%E7%94%9F%E6%95%88%22%29%29%0A%09%09%09else%3A%0A%09%09%09%09ui.message%28_%28%22%E7%A7%BB%E9%99%A4%20QT_ACCESSIBILITY%20%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%E5%A4%B1%E6%95%97%22%29%29%0A%09%09else%3A%0A%09%09%09if%20_setQtAccessible%28True%29%3A%0A%09%09%09%09ui.message%28_%28%22%E5%B7%B2%E8%A8%AD%E5%AE%9A%20QT_ACCESSIBILITY%3D1%EF%BC%8C%E9%87%8D%E5%95%9F%20LINE%20%E5%BE%8C%E7%94%9F%E6%95%88%22%29%29%0A%09%09%09else%3A%0A%09%09%09%09ui.message%28_%28%22%E8%A8%AD%E5%AE%9A%20QT_ACCESSIBILITY%20%E7%92%B0%E5%A2%83%E8%AE%8A%E6%95%B8%E5%A4%B1%E6%95%97%22%29%29%0A%60%60%60%0A%0A%E8%A3%9C%E4%B8%8A%E8%A3%9D%E9%A3%BE%E5%99%A8%E5%BE%8C%EF%BC%8C%E4%B9%9F%E5%BB%BA%E8%AD%B0%E5%9C%A8%E9%81%B8%E5%96%AE%E9%A0%85%E7%9B%AE%E6%A8%99%E7%B1%A4%E4%B8%AD%E5%8A%A0%E5%85%A5%E5%BF%AB%E6%8D%B7%E9%8D%B5%E6%8F%90%E7%A4%BA%EF%BC%88%60%2B%20%22%5CtNVDA%2BShift%2BA%22%60%EF%BC%89%EF%BC%8C%E8%88%87%E5%85%B6%E4%BB%96%E9%81%B8%E5%96%AE%E9%A0%85%E7%9B%AE%E4%BF%9D%E6%8C%81%E4%B8%80%E8%87%B4%E3%80%82%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 6087-6099

Comment:
**缺少 `@script` 裝飾器，快捷鍵無法運作**

`script_toggleQtAccessible` 雖然遵循 NVDA 的 `script_*` 命名慣例，但完全缺少 `@script` 裝飾器與 `gesture` 宣告。如此一來，NVDA 不會將任何鍵盤手勢綁定到此函式，使用者無論按下 `NVDA+Shift+A` 或其他任何組合鍵，都不會有任何反應。

PR 說明明確列出「**Keyboard shortcut: NVDA+Shift+A to toggle the setting**」，但搜尋整個程式碼庫確認此手勢並未被宣告於任何地方。

對照同一檔案內其他腳本（如 `script_reportLineInfo`），正確的寫法應為：

```suggestion
	@script(
		# Translators: Description of a script to toggle Qt accessibility env var
		description=_("切換 Qt 無障礙環境變數"),
		gesture="kb:NVDA+shift+a",
		category="LINE Desktop",
	)
	def script_toggleQtAccessible(self, gesture):
		"""Toggle QT_ACCESSIBILITY=1 user environment variable."""
		currentlySet = _isQtAccessibleSet()
		if currentlySet:
			if _setQtAccessible(False):
				ui.message(_("已移除 QT_ACCESSIBILITY 環境變數，重啟 LINE 後生效"))
			else:
				ui.message(_("移除 QT_ACCESSIBILITY 環境變數失敗"))
		else:
			if _setQtAccessible(True):
				ui.message(_("已設定 QT_ACCESSIBILITY=1，重啟 LINE 後生效"))
			else:
				ui.message(_("設定 QT_ACCESSIBILITY 環境變數失敗"))
```

補上裝飾器後，也建議在選單項目標籤中加入快捷鍵提示（`+ "\tNVDA+Shift+A"`），與其他選單項目保持一致。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Remove NVDA+Shift+A shortcut from Qt acc..."](https://github.com/keyang556/linedesktopnvda/commit/3c77cee691864ab709cc1ab052701fea3b172c04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28190571)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->