### PR TITLE
新增 NVDA+Windows+I 圖片描述功能（Google AI Gemma 4）

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1693,6 +1693,18 @@ _currentChatRoomName = None
 # Flag to suppress addon while a file dialog is open
 _suppressAddon = False
 
+# Google AI API key used by NVDA+Windows+I image description.
+# This is an AI Studio key bundled for end-user convenience.
+_IMAGE_DESCRIPTION_API_KEY = (
+	"AQ.Ab8RN6KSiZcHSBEjCN7rZN5kP201HIwQJFGPBKdXgxShFZD7HA"
+)
+_IMAGE_DESCRIPTION_MODEL = "gemma-4-31b-it"
+_IMAGE_DESCRIPTION_ENDPOINT = (
+	"https://generativelanguage.googleapis.com/v1beta/models/"
+	"{model}:generateContent?key={key}"
+)
+_IMAGE_DESCRIPTION_PROMPT = "請用繁體中文簡要描述這張圖片的內容。"
+
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")
 _NOTES_OCR_KEYWORDS = (
 	"記事本", "相簿", "已儲存",
@@ -1714,6 +1726,151 @@ _nameRecursionGuard = set()
 # Thread-level recursion depth counter as ultimate safety net
 _nameRecursionDepth = 0
 _MAX_NAME_RECURSION_DEPTH = 5
+
+
+def _captureRegionAsPng(left, top, width, height):
+	"""Capture the given screen rect and return PNG bytes, or None on failure.
+
+	Uses NVDA's ``screenBitmap`` to grab pixels and encodes them to PNG
+	with only the standard library (``struct`` + ``zlib``).  Keeping the
+	encoder self-contained avoids taking a hard dependency on Pillow,
+	which is not bundled with NVDA.
+	"""
+	if width <= 0 or height <= 0:
+		return None
+
+	try:
+		import ctypes as _ctypes
+		import screenBitmap
+		sb = screenBitmap.ScreenBitmap(width, height)
+		pixels = sb.captureImage(left, top, width, height)
+		# pixels is a ctypes array of RGBQUAD (BGRA, 4 bytes per pixel).
+		bgra = bytearray(_ctypes.string_at(pixels, width * height * 4))
+	except Exception as e:
+		log.debug(
+			f"LINE: _captureRegionAsPng capture failed: {e}",
+			exc_info=True,
+		)
+		return None
+
+	try:
+		import struct
+		import zlib
+		# Swap B <-> R channels in place to turn BGRA into RGBA.
+		# Tuple assignment evaluates the RHS fully before assigning.
+		bgra[0::4], bgra[2::4] = bgra[2::4], bgra[0::4]
+		rgba = bgra
+
+		stride = width * 4
+		raw = bytearray(height * (stride + 1))
+		# Prepend a 0x00 filter byte to every scanline (filter type: None).
+		for y in range(height):
+			srcStart = y * stride
+			dstStart = y * (stride + 1)
+			raw[dstStart] = 0
+			raw[dstStart + 1:dstStart + 1 + stride] = (
+				rgba[srcStart:srcStart + stride]
+			)
+
+		def _chunk(tag, data):
+			return (
+				struct.pack(">I", len(data))
+				+ tag
+				+ data
+				+ struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+			)
+
+		signature = b"\x89PNG\r\n\x1a\n"
+		ihdr = struct.pack(
+			">IIBBBBB",
+			width, height,
+			8,  # bit depth
+			6,  # color type: RGBA
+			0, 0, 0,  # compression, filter, interlace
+		)
+		idat = zlib.compress(bytes(raw), 6)
+		return (
+			signature
+			+ _chunk(b"IHDR", ihdr)
+			+ _chunk(b"IDAT", idat)
+			+ _chunk(b"IEND", b"")
+		)
+	except Exception as e:
+		log.debug(
+			f"LINE: _captureRegionAsPng encode failed: {e}",
+			exc_info=True,
+		)
+		return None
+
+
+def _describeImageBytes(pngBytes, timeout=30.0):
+	"""Send PNG image bytes to Google AI and return the description, or None."""
+	if not pngBytes:
+		return None
+	try:
+		import base64
+		import json
+		import urllib.request
+		url = _IMAGE_DESCRIPTION_ENDPOINT.format(
+			model=_IMAGE_DESCRIPTION_MODEL,
+			key=_IMAGE_DESCRIPTION_API_KEY,
+		)
+		body = {
+			"contents": [
+				{
+					"parts": [
+						{"text": _IMAGE_DESCRIPTION_PROMPT},
+						{
+							"inline_data": {
+								"mime_type": "image/png",
+								"data": base64.b64encode(pngBytes).decode(
+									"ascii"
+								),
+							}
+						},
+					]
+				}
+			]
+		}
+		req = urllib.request.Request(
+			url,
+			data=json.dumps(body).encode("utf-8"),
+			headers={"Content-Type": "application/json"},
+			method="POST",
+		)
+		with urllib.request.urlopen(req, timeout=timeout) as resp:
+			raw = resp.read()
+		data = json.loads(raw.decode("utf-8", errors="replace"))
+	except Exception as e:
+		log.warning(
+			f"LINE: image description request failed: {e}",
+			exc_info=True,
+		)
+		return None
+
+	try:
+		candidates = data.get("candidates") or []
+		if not candidates:
+			log.info(
+				f"LINE: image description returned no candidates: {data!r}"
+			)
+			return None
+		parts = (
+			candidates[0].get("content", {}).get("parts", [])
+			if isinstance(candidates[0], dict)
+			else []
+		)
+		for part in parts:
+			if isinstance(part, dict):
+				text = part.get("text")
+				if text:
+					return text.strip()
+	except Exception as e:
+		log.warning(
+			f"LINE: image description response parse failed: {e}",
+			exc_info=True,
+		)
+	return None
 
 
 def _getDpiScale(hwnd=None):
@@ -8475,6 +8632,66 @@ class AppModule(appModuleHandler.AppModule):
 			self._suppressAddonForFileDialog("Save As selected")
 
 		self._contextMenuAction(0, "另存新檔", afterCallback=_afterSaveAs)
+
+	@script(
+		gesture="kb:NVDA+windows+i",
+		# Translators: Input help message for the image-description command.
+		description=_("Describe the current image message using Google AI"),
+		category="LINE",
+	)
+	def script_describeImage(self, gesture):
+		"""Send the focused message bubble to Google AI and speak the result.
+
+		Captures the UIA bounding rect of the currently focused message,
+		encodes it as PNG, and asks the configured Gemma vision model to
+		describe the image.  The HTTP request runs on a worker thread so
+		NVDA's main loop stays responsive; the reply is announced via
+		``wx.CallAfter(ui.message, ...)`` to stay on the UI thread.
+		"""
+		if _suppressAddon:
+			return
+
+		try:
+			handler = UIAHandler.handler
+			rawEl = handler.clientObject.GetFocusedElement()
+			if not rawEl:
+				ui.message(_("找不到目前的訊息"))
+				return
+			rect = rawEl.CurrentBoundingRectangle
+			left = int(rect.left)
+			top = int(rect.top)
+			width = int(rect.right - rect.left)
+			height = int(rect.bottom - rect.top)
+		except Exception as e:
+			log.debug(
+				f"LINE: script_describeImage getElement failed: {e}",
+				exc_info=True,
+			)
+			ui.message(_("找不到目前的訊息"))
+			return
+
+		if width <= 0 or height <= 0:
+			ui.message(_("找不到目前的訊息"))
+			return
+
+		pngBytes = _captureRegionAsPng(left, top, width, height)
+		if not pngBytes:
+			ui.message(_("擷取圖片失敗"))
+			return
+
+		ui.message(_("描述圖片中，請稍候"))
+
+		import threading
+
+		def _worker():
+			import wx
+			description = _describeImageBytes(pngBytes)
+			if description:
+				wx.CallAfter(ui.message, description)
+			else:
+				wx.CallAfter(ui.message, _("圖片描述失敗"))
+
+		threading.Thread(target=_worker, daemon=True).start()
 
 	def _isVoiceDurationLine(self, text):
 		"""Return True when OCR text looks like a voice duration label."""


### PR DESCRIPTION
## Summary

- 新增 `NVDA+Windows+I` 快捷鍵：瀏覽到圖片訊息時，觸發 AI 描述圖片內容
- 使用 Google AI API，模型為 `gemma-4-31b-it`
- 描述結果以繁體中文透過 NVDA 語音播報

## 變更內容

- **`_IMAGE_DESCRIPTION_*` 常數**：API Key、模型名稱、端點、提示詞
- **`_captureRegionAsPng`**：使用 NVDA 內建 `screenBitmap` 擷取畫面區域，並以 `struct`+`zlib` 純標準函式庫編碼為 PNG（不依賴 Pillow）
- **`_describeImageBytes`**：透過 `urllib.request` 呼叫 Google AI API，在背景執行緒執行以避免阻塞 NVDA 主迴圈
- **`script_describeImage`**（gesture: `NVDA+Windows+I`）：取得目前聚焦訊息的 UIA 邊界矩形 → 截圖 → 呼叫 API → 以 `wx.CallAfter(ui.message, ...)` 回到 UI 執行緒播報

## Test plan

- [x] 在 LINE 訊息列表中導覽到圖片訊息，按下 NVDA+Windows+I，確認 NVDA 播報「描述圖片中，請稍候」後播報圖片描述
- [ ] 確認 API 失敗時播報「圖片描述失敗」
- [x] 確認其他訊息類型不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 為 LINE Desktop NVDA 附加元件新增 `NVDA+Windows+I` 快捷鍵，可對目前聚焦的訊息氣泡截圖，並呼叫 Google AI（Gemma 4 視覺模型）以繁體中文語音播報圖片描述。PNG 編碼採純標準函式庫實作（`struct` + `zlib`），HTTP 請求在背景執行緒中執行以避免阻塞 NVDA 主迴圈。

主要問題如下：

- **P0 安全性**：Google AI Studio API 金鑰以明文硬編碼於公開原始碼（`_IMAGE_DESCRIPTION_API_KEY`），任何人皆可取用；Google 的自動掃描亦可能主動撤銷，致使所有使用者的功能失效。應改由使用者自行提供金鑰。
- **P1 邏輯**：`script_describeImage` 未驗證聚焦元素是否為圖片訊息，任何類型的訊息（文字、按鈕等）皆會被截圖並上傳至外部伺服器，造成隱私外洩與使用者困惑。
- **P2 效能**：PNG 捕捉與 zlib 壓縮於 NVDA 主執行緒同步執行，對大型元素可能造成短暫卡頓；建議將此步驟移入背景執行緒。

<h3>Confidence Score: 2/5</h3>

此 PR 尚不宜合併，硬編碼的公開 API 金鑰為阻斷性安全問題，需在合併前解決。

核心邏輯（PNG 編碼、背景執行緒、wx.CallAfter 回 UI 執行緒）實作正確。然而，API 金鑰明文寫入公開 repo（P0）會立即造成金鑰濫用或被 Google 撤銷，導致功能完全失效；此外，未驗證訊息類型（P1）意味著任何聚焦元素的截圖都會被上傳至外部服務。在這兩個問題修復之前，功能的可靠性與安全性均無法保證。

addon/appModules/line.py — 特別是第 1698–1700 行（API 金鑰）及 script_describeImage 方法（訊息類型驗證）。

<details open><summary><h3>Security Review</h3></summary>

- **金鑰外洩（`addon/appModules/line.py:1698-1700`）**：Google AI Studio API 金鑰以明文形式硬編碼於公開原始碼中。任何人皆可取用此金鑰，Google 的自動掃描機制亦可能主動撤銷，導致功能失效。
- **隱私資料傳輸（`_describeImageBytes`）**：使用者的 LINE 訊息截圖（可能含有私人文字或影像）會在未明確告知的情況下，透過 `urllib.request` 上傳至 Google 的生成式 AI API（`generativelanguage.googleapis.com`），存在資料外洩風險。
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 NVDA+Windows+I 圖片描述功能，包含 _captureRegionAsPng、_describeImageBytes 及 script_describeImage；存在硬編碼 API 金鑰（安全 P0）、未驗證訊息類型（邏輯 P1）以及主執行緒 zlib 壓縮（效能 P2）等問題。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as 使用者
    participant NVDA as NVDA 主執行緒
    participant BG as 背景執行緒
    participant G as Google AI API

    U->>NVDA: 按下 NVDA+Windows+I
    NVDA->>NVDA: GetFocusedElement() → 取得 UIA 邊界矩形
    NVDA->>NVDA: _captureRegionAsPng() (screenBitmap + zlib 壓縮，同步)
    NVDA->>U: ui.message(描述圖片中，請稍候)
    NVDA->>BG: threading.Thread(_worker).start()
    BG->>G: POST /v1beta/models/gemma-4-31b-it:generateContent (含 base64 PNG + API 金鑰)
    G-->>BG: JSON 回應（候選文字）
    BG->>NVDA: wx.CallAfter(ui.message, description)
    NVDA->>U: 語音播報圖片描述
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aaddon%2FappModules%2Fline.py%3A1698-1700%0A**%E7%A1%AC%E7%B7%A8%E7%A2%BC%E7%9A%84%20API%20%E9%87%91%E9%91%B0%EF%BC%88%E5%AE%89%E5%85%A8%E6%80%A7%E9%A2%A8%E9%9A%AA%EF%BC%89**%0A%0A%60_IMAGE_DESCRIPTION_API_KEY%60%20%E8%A2%AB%E6%98%8E%E6%96%87%E5%AF%AB%E5%85%A5%E5%85%AC%E9%96%8B%E7%9A%84%E5%8E%9F%E5%A7%8B%E7%A2%BC%E4%B8%AD%E3%80%82%E9%80%99%E6%9C%83%E5%B8%B6%E4%BE%86%E4%BB%A5%E4%B8%8B%E5%9A%B4%E9%87%8D%E5%95%8F%E9%A1%8C%EF%BC%9A%0A%0A1.%20**%E4%BB%BB%E4%BD%95%E4%BA%BA%E9%83%BD%E8%83%BD%E5%8F%96%E7%94%A8%E6%AD%A4%E9%87%91%E9%91%B0**%EF%BC%9A%E7%80%8F%E8%A6%BD%20GitHub%20%E7%9A%84%E4%BB%BB%E4%BD%95%E4%BA%BA%E7%9A%86%E5%8F%AF%E8%A4%87%E8%A3%BD%E6%AD%A4%E9%87%91%E9%91%B0%E4%B8%A6%E8%87%AA%E8%A1%8C%E4%BD%BF%E7%94%A8%EF%BC%8C%E9%80%A0%E6%88%90%E9%85%8D%E9%A1%8D%E8%A2%AB%E6%BF%AB%E7%94%A8%EF%BC%8C%E7%94%9A%E8%87%B3%E7%94%A2%E7%94%9F%E8%A8%88%E8%B2%BB%E3%80%82%0A2.%20**Google%20%E7%9A%84%E7%A7%98%E5%AF%86%E6%8E%83%E6%8F%8F%E6%A9%9F%E5%88%B6**%EF%BC%9AGoogle%20%E6%9C%83%E8%87%AA%E5%8B%95%E6%8E%83%E6%8F%8F%E5%85%AC%E9%96%8B%20repo%EF%BC%8C%E7%99%BC%E7%8F%BE%E9%87%91%E9%91%B0%E5%BE%8C%E5%8F%AF%E8%83%BD%E7%AB%8B%E5%8D%B3%E6%92%A4%E9%8A%B7%EF%BC%8C%E5%B0%8E%E8%87%B4%E6%89%80%E6%9C%89%E4%BD%BF%E7%94%A8%E8%80%85%E7%9A%84%E6%AD%A4%E5%8A%9F%E8%83%BD%E5%A4%B1%E6%95%88%E3%80%82%0A3.%20**%E9%9A%B1%E7%A7%81%E5%95%8F%E9%A1%8C**%EF%BC%9A%E6%88%AA%E5%9C%96%E6%9C%83%E8%A2%AB%E4%B8%8A%E5%82%B3%E8%87%B3%20Google%20%E7%9A%84%20API%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E9%9C%80%E4%BA%8B%E5%85%88%E7%9F%A5%E6%83%85%E4%B8%A6%E5%90%8C%E6%84%8F%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E7%9A%84%E6%9B%BF%E4%BB%A3%E6%96%B9%E6%A1%88%EF%BC%88%E4%BE%9D%E5%84%AA%E5%85%88%E9%A0%86%E5%BA%8F%EF%BC%89%EF%BC%9A%0A%0A-%20**%E6%96%B9%E6%A1%88%20A%EF%BC%88%E6%9C%80%E4%BD%B3%EF%BC%89**%EF%BC%9A%E5%AE%8C%E5%85%A8%E7%A7%BB%E9%99%A4%E5%85%A7%E5%BB%BA%E9%87%91%E9%91%B0%EF%BC%8C%E6%94%B9%E7%94%B1%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%20NVDA%20%E8%A8%AD%E5%AE%9A%E4%BB%8B%E9%9D%A2%E4%B8%AD%E8%BC%B8%E5%85%A5%E8%87%AA%E5%B7%B1%E7%9A%84%E9%87%91%E9%91%B0%E4%B8%A6%E5%84%B2%E5%AD%98%E8%87%B3%20%60nvda.ini%60%E3%80%82%0A-%20**%E6%96%B9%E6%A1%88%20B%EF%BC%88%E6%AC%A1%E4%BD%B3%EF%BC%89**%EF%BC%9A%E5%9C%A8%20%60addon%2FglobalPlugins%60%20%E6%88%96%20%60installTasks.py%60%20%E6%8F%90%E7%A4%BA%E4%BD%BF%E7%94%A8%E8%80%85%E6%96%BC%E5%AE%89%E8%A3%9D%E6%99%82%E8%BC%B8%E5%85%A5%E9%87%91%E9%91%B0%E3%80%82%0A-%20**%E6%96%B9%E6%A1%88%20C%EF%BC%88%E6%9C%80%E4%BD%8E%E9%99%90%E5%BA%A6%EF%BC%89**%EF%BC%9A%E8%87%B3%E5%B0%91%E5%9C%A8%E5%8A%9F%E8%83%BD%E8%AA%AA%E6%98%8E%E4%B8%AD%E5%8A%A0%E5%85%A5%E6%98%8E%E7%A2%BA%E8%AD%A6%E8%AA%9E%EF%BC%8C%E8%AA%AA%E6%98%8E%E9%87%91%E9%91%B0%E6%9C%89%E6%95%88%E6%9C%9F%E9%99%90%E5%8F%8A%E9%9A%B1%E7%A7%81%E9%A2%A8%E9%9A%AA%EF%BC%8C%E8%AE%93%E4%BD%BF%E7%94%A8%E8%80%85%E8%87%AA%E8%A1%8C%E6%9B%BF%E6%8F%9B%E3%80%82%0A%0A%60%60%60suggestion%0A_IMAGE_DESCRIPTION_API_KEY%20%3D%20%22%22%20%20%23%20%E8%AB%8B%E4%BD%BF%E7%94%A8%E8%80%85%E8%87%AA%E8%A1%8C%E5%A1%AB%E5%85%A5%20Google%20AI%20Studio%20API%20%E9%87%91%E9%91%B0%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aaddon%2FappModules%2Fline.py%3A8642-8694%0A**%E6%9C%AA%E9%A9%97%E8%AD%89%E8%81%9A%E7%84%A6%E5%85%83%E7%B4%A0%E6%98%AF%E5%90%A6%E7%82%BA%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF**%0A%0A%60script_describeImage%60%20%E6%9C%83%E5%B0%8D%E4%BB%BB%E4%BD%95%E8%81%9A%E7%84%A6%E7%9A%84%20UIA%20%E5%85%83%E7%B4%A0%EF%BC%88%E5%8C%85%E5%90%AB%E6%96%87%E5%AD%97%E8%A8%8A%E6%81%AF%E3%80%81%E6%8C%89%E9%88%95%E3%80%81%E8%BC%B8%E5%85%A5%E6%AC%84%E4%BD%8D%E7%AD%89%EF%BC%89%E6%88%AA%E5%9C%96%E4%B8%A6%E9%80%81%E8%87%B3%20Google%20AI%20API%EF%BC%8C%E8%80%8C%E9%9D%9E%E5%8F%AA%E9%87%9D%E5%B0%8D%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E3%80%82%E8%8B%A5%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%E9%9D%9E%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E4%B8%8A%E6%8C%89%E4%B8%8B%E5%BF%AB%E6%8D%B7%E9%8D%B5%EF%BC%8C%E6%9C%83%E6%9C%89%E4%BB%A5%E4%B8%8B%E5%95%8F%E9%A1%8C%EF%BC%9A%0A%0A1.%20%E6%88%AA%E5%9C%96%E5%8F%AF%E8%83%BD%E5%8C%85%E5%90%AB%E7%A7%81%E4%BA%BA%E6%96%87%E5%AD%97%E5%85%A7%E5%AE%B9%E4%B8%A6%E4%B8%8A%E5%82%B3%E8%87%B3%E5%A4%96%E9%83%A8%E4%BC%BA%E6%9C%8D%E5%99%A8%E3%80%82%0A2.%20AI%20%E5%9B%9E%E5%82%B3%E7%9A%84%E6%98%AF%E5%B0%8D%E9%9D%9E%E5%9C%96%E7%89%87%E5%85%83%E7%B4%A0%E7%9A%84%E6%8F%8F%E8%BF%B0%EF%BC%8C%E9%80%A0%E6%88%90%E4%BD%BF%E7%94%A8%E8%80%85%E5%9B%B0%E6%83%91%E3%80%82%0A3.%20%E6%B5%AA%E8%B2%BB%20API%20%E9%85%8D%E9%A1%8D%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%9C%A8%E6%93%B7%E5%8F%96%E5%89%8D%EF%BC%8C%E5%85%88%E7%A2%BA%E8%AA%8D%E8%81%9A%E7%84%A6%E5%85%83%E7%B4%A0%E7%9A%84%20accessible%20name%20%E6%88%96%20ControlType%20%E7%AC%A6%E5%90%88%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E7%9A%84%E7%89%B9%E5%BE%B5%EF%BC%88%E4%BE%8B%E5%A6%82%E5%88%A4%E6%96%B7%E6%98%AF%E5%90%A6%E5%90%AB%E6%9C%89%E5%9C%96%E7%89%87%E7%9A%84%20ControlType%EF%BC%8C%E6%88%96%E5%8F%83%E8%80%83%E6%97%A2%E6%9C%89%E7%A8%8B%E5%BC%8F%E7%A2%BC%E4%B8%AD%E8%BE%A8%E8%AD%98%E8%A8%8A%E6%81%AF%E9%A1%9E%E5%9E%8B%E7%9A%84%E9%82%8F%E8%BC%AF%EF%BC%89%EF%BC%8C%E5%A6%82%E4%B8%8B%E4%BE%8B%EF%BC%9A%0A%0A%60%60%60python%0A%23%20%E5%9C%A8%E5%8F%96%E5%BE%97%20rect%20%E4%B9%8B%E5%BE%8C%EF%BC%8C%E5%91%BC%E5%8F%AB%20_captureRegionAsPng%20%E4%B9%8B%E5%89%8D%E5%8A%A0%E5%85%A5%E9%A1%9E%E5%9E%8B%E5%88%A4%E6%96%B7%0Aname%20%3D%20rawEl.CurrentName%20or%20%22%22%0A%23%20%E5%81%87%E8%A8%AD%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E5%9C%A8%20accessible%20name%20%E4%B8%AD%E5%8C%85%E5%90%AB%E7%89%B9%E5%AE%9A%E9%97%9C%E9%8D%B5%E5%AD%97%EF%BC%88%E9%9C%80%E4%BE%9D%E5%AF%A6%E9%9A%9B%20LINE%20UIA%20tree%20%E8%AA%BF%E6%95%B4%EF%BC%89%0Aif%20not%20_looksLikeImageMessage%28name%29%3A%0A%20%20%20%20ui.message%28_%28%22%E7%9B%AE%E5%89%8D%E8%A8%8A%E6%81%AF%E9%9D%9E%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%22%29%29%0A%20%20%20%20return%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aaddon%2FappModules%2Fline.py%3A8677-8694%0A**PNG%20%E7%B7%A8%E7%A2%BC%EF%BC%88%E5%90%AB%20zlib%20%E5%A3%93%E7%B8%AE%EF%BC%89%E5%9C%A8%E4%B8%BB%E5%9F%B7%E8%A1%8C%E7%B7%92%E5%9F%B7%E8%A1%8C**%0A%0A%60_captureRegionAsPng%60%20%E5%8C%85%E5%90%AB%20%60zlib.compress%28bytes%28raw%29%2C%206%29%60%20%E5%91%BC%E5%8F%AB%EF%BC%8C%E9%80%99%E6%AD%A5%E9%A9%9F%E5%B0%8D%E5%A4%A7%E5%9E%8B%E5%85%83%E7%B4%A0%EF%BC%88%E4%BE%8B%E5%A6%82%20LINE%20%E7%9A%84%E9%AB%98%E8%A7%A3%E6%9E%90%E5%BA%A6%E5%9C%96%E7%89%87%E6%B0%A3%E6%B3%A1%EF%BC%89%E5%8F%AF%E8%83%BD%E9%9C%80%E8%A6%81%E6%95%B8%E5%8D%81%E6%AF%AB%E7%A7%92%EF%BC%8C%E4%B8%94%E7%9B%AE%E5%89%8D%E5%9C%A8%20NVDA%20%E4%B8%BB%E5%9F%B7%E8%A1%8C%E7%B7%92%E5%90%8C%E6%AD%A5%E5%9F%B7%E8%A1%8C%EF%BC%8C%E5%8F%AF%E8%83%BD%E9%80%A0%E6%88%90%E7%9F%AD%E6%9A%AB%E5%8D%A1%E9%A0%93%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%B0%87%E6%88%AA%E5%9C%96%E8%88%87%20PNG%20%E7%B7%A8%E7%A2%BC%E4%B9%9F%E7%A7%BB%E5%85%A5%E8%83%8C%E6%99%AF%E5%9F%B7%E8%A1%8C%E7%B7%92%EF%BC%9A%0A%0A%60%60%60python%0Aui.message%28_%28%22%E6%8F%8F%E8%BF%B0%E5%9C%96%E7%89%87%E4%B8%AD%EF%BC%8C%E8%AB%8B%E7%A8%8D%E5%80%99%22%29%29%0A%0Aimport%20threading%0A%0A_left%2C%20_top%2C%20_width%2C%20_height%20%3D%20left%2C%20top%2C%20width%2C%20height%0A%0Adef%20_worker%28%29%3A%0A%20%20%20%20import%20wx%0A%20%20%20%20pngBytes%20%3D%20_captureRegionAsPng%28_left%2C%20_top%2C%20_width%2C%20_height%29%0A%20%20%20%20if%20not%20pngBytes%3A%0A%20%20%20%20%20%20%20%20wx.CallAfter%28ui.message%2C%20_%28%22%E6%93%B7%E5%8F%96%E5%9C%96%E7%89%87%E5%A4%B1%E6%95%97%22%29%29%0A%20%20%20%20%20%20%20%20return%0A%20%20%20%20description%20%3D%20_describeImageBytes%28pngBytes%29%0A%20%20%20%20if%20description%3A%0A%20%20%20%20%20%20%20%20wx.CallAfter%28ui.message%2C%20description%29%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20wx.CallAfter%28ui.message%2C%20_%28%22%E5%9C%96%E7%89%87%E6%8F%8F%E8%BF%B0%E5%A4%B1%E6%95%97%22%29%29%0A%0Athreading.Thread%28target%3D_worker%2C%20daemon%3DTrue%29.start%28%29%0A%60%60%60%0A%0A%E9%80%99%E6%A8%A3%E4%B8%BB%E5%9F%B7%E8%A1%8C%E7%B7%92%E5%8F%AA%E9%9C%80%E5%8F%96%E5%BE%97%E9%82%8A%E7%95%8C%E7%9F%A9%E5%BD%A2%E5%8D%B3%E5%8F%AF%EF%BC%8C%E6%88%AA%E5%9C%96%E8%88%87%E5%A3%93%E7%B8%AE%E5%9D%87%E5%9C%A8%E8%83%8C%E6%99%AF%E5%AE%8C%E6%88%90%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda&pr=55&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Fstrange-mendeleev%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fstrange-mendeleev%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aaddon%2FappModules%2Fline.py%3A1698-1700%0A**%E7%A1%AC%E7%B7%A8%E7%A2%BC%E7%9A%84%20API%20%E9%87%91%E9%91%B0%EF%BC%88%E5%AE%89%E5%85%A8%E6%80%A7%E9%A2%A8%E9%9A%AA%EF%BC%89**%0A%0A%60_IMAGE_DESCRIPTION_API_KEY%60%20%E8%A2%AB%E6%98%8E%E6%96%87%E5%AF%AB%E5%85%A5%E5%85%AC%E9%96%8B%E7%9A%84%E5%8E%9F%E5%A7%8B%E7%A2%BC%E4%B8%AD%E3%80%82%E9%80%99%E6%9C%83%E5%B8%B6%E4%BE%86%E4%BB%A5%E4%B8%8B%E5%9A%B4%E9%87%8D%E5%95%8F%E9%A1%8C%EF%BC%9A%0A%0A1.%20**%E4%BB%BB%E4%BD%95%E4%BA%BA%E9%83%BD%E8%83%BD%E5%8F%96%E7%94%A8%E6%AD%A4%E9%87%91%E9%91%B0**%EF%BC%9A%E7%80%8F%E8%A6%BD%20GitHub%20%E7%9A%84%E4%BB%BB%E4%BD%95%E4%BA%BA%E7%9A%86%E5%8F%AF%E8%A4%87%E8%A3%BD%E6%AD%A4%E9%87%91%E9%91%B0%E4%B8%A6%E8%87%AA%E8%A1%8C%E4%BD%BF%E7%94%A8%EF%BC%8C%E9%80%A0%E6%88%90%E9%85%8D%E9%A1%8D%E8%A2%AB%E6%BF%AB%E7%94%A8%EF%BC%8C%E7%94%9A%E8%87%B3%E7%94%A2%E7%94%9F%E8%A8%88%E8%B2%BB%E3%80%82%0A2.%20**Google%20%E7%9A%84%E7%A7%98%E5%AF%86%E6%8E%83%E6%8F%8F%E6%A9%9F%E5%88%B6**%EF%BC%9AGoogle%20%E6%9C%83%E8%87%AA%E5%8B%95%E6%8E%83%E6%8F%8F%E5%85%AC%E9%96%8B%20repo%EF%BC%8C%E7%99%BC%E7%8F%BE%E9%87%91%E9%91%B0%E5%BE%8C%E5%8F%AF%E8%83%BD%E7%AB%8B%E5%8D%B3%E6%92%A4%E9%8A%B7%EF%BC%8C%E5%B0%8E%E8%87%B4%E6%89%80%E6%9C%89%E4%BD%BF%E7%94%A8%E8%80%85%E7%9A%84%E6%AD%A4%E5%8A%9F%E8%83%BD%E5%A4%B1%E6%95%88%E3%80%82%0A3.%20**%E9%9A%B1%E7%A7%81%E5%95%8F%E9%A1%8C**%EF%BC%9A%E6%88%AA%E5%9C%96%E6%9C%83%E8%A2%AB%E4%B8%8A%E5%82%B3%E8%87%B3%20Google%20%E7%9A%84%20API%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E9%9C%80%E4%BA%8B%E5%85%88%E7%9F%A5%E6%83%85%E4%B8%A6%E5%90%8C%E6%84%8F%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E7%9A%84%E6%9B%BF%E4%BB%A3%E6%96%B9%E6%A1%88%EF%BC%88%E4%BE%9D%E5%84%AA%E5%85%88%E9%A0%86%E5%BA%8F%EF%BC%89%EF%BC%9A%0A%0A-%20**%E6%96%B9%E6%A1%88%20A%EF%BC%88%E6%9C%80%E4%BD%B3%EF%BC%89**%EF%BC%9A%E5%AE%8C%E5%85%A8%E7%A7%BB%E9%99%A4%E5%85%A7%E5%BB%BA%E9%87%91%E9%91%B0%EF%BC%8C%E6%94%B9%E7%94%B1%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%20NVDA%20%E8%A8%AD%E5%AE%9A%E4%BB%8B%E9%9D%A2%E4%B8%AD%E8%BC%B8%E5%85%A5%E8%87%AA%E5%B7%B1%E7%9A%84%E9%87%91%E9%91%B0%E4%B8%A6%E5%84%B2%E5%AD%98%E8%87%B3%20%60nvda.ini%60%E3%80%82%0A-%20**%E6%96%B9%E6%A1%88%20B%EF%BC%88%E6%AC%A1%E4%BD%B3%EF%BC%89**%EF%BC%9A%E5%9C%A8%20%60addon%2FglobalPlugins%60%20%E6%88%96%20%60installTasks.py%60%20%E6%8F%90%E7%A4%BA%E4%BD%BF%E7%94%A8%E8%80%85%E6%96%BC%E5%AE%89%E8%A3%9D%E6%99%82%E8%BC%B8%E5%85%A5%E9%87%91%E9%91%B0%E3%80%82%0A-%20**%E6%96%B9%E6%A1%88%20C%EF%BC%88%E6%9C%80%E4%BD%8E%E9%99%90%E5%BA%A6%EF%BC%89**%EF%BC%9A%E8%87%B3%E5%B0%91%E5%9C%A8%E5%8A%9F%E8%83%BD%E8%AA%AA%E6%98%8E%E4%B8%AD%E5%8A%A0%E5%85%A5%E6%98%8E%E7%A2%BA%E8%AD%A6%E8%AA%9E%EF%BC%8C%E8%AA%AA%E6%98%8E%E9%87%91%E9%91%B0%E6%9C%89%E6%95%88%E6%9C%9F%E9%99%90%E5%8F%8A%E9%9A%B1%E7%A7%81%E9%A2%A8%E9%9A%AA%EF%BC%8C%E8%AE%93%E4%BD%BF%E7%94%A8%E8%80%85%E8%87%AA%E8%A1%8C%E6%9B%BF%E6%8F%9B%E3%80%82%0A%0A%60%60%60suggestion%0A_IMAGE_DESCRIPTION_API_KEY%20%3D%20%22%22%20%20%23%20%E8%AB%8B%E4%BD%BF%E7%94%A8%E8%80%85%E8%87%AA%E8%A1%8C%E5%A1%AB%E5%85%A5%20Google%20AI%20Studio%20API%20%E9%87%91%E9%91%B0%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aaddon%2FappModules%2Fline.py%3A8642-8694%0A**%E6%9C%AA%E9%A9%97%E8%AD%89%E8%81%9A%E7%84%A6%E5%85%83%E7%B4%A0%E6%98%AF%E5%90%A6%E7%82%BA%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF**%0A%0A%60script_describeImage%60%20%E6%9C%83%E5%B0%8D%E4%BB%BB%E4%BD%95%E8%81%9A%E7%84%A6%E7%9A%84%20UIA%20%E5%85%83%E7%B4%A0%EF%BC%88%E5%8C%85%E5%90%AB%E6%96%87%E5%AD%97%E8%A8%8A%E6%81%AF%E3%80%81%E6%8C%89%E9%88%95%E3%80%81%E8%BC%B8%E5%85%A5%E6%AC%84%E4%BD%8D%E7%AD%89%EF%BC%89%E6%88%AA%E5%9C%96%E4%B8%A6%E9%80%81%E8%87%B3%20Google%20AI%20API%EF%BC%8C%E8%80%8C%E9%9D%9E%E5%8F%AA%E9%87%9D%E5%B0%8D%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E3%80%82%E8%8B%A5%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%E9%9D%9E%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E4%B8%8A%E6%8C%89%E4%B8%8B%E5%BF%AB%E6%8D%B7%E9%8D%B5%EF%BC%8C%E6%9C%83%E6%9C%89%E4%BB%A5%E4%B8%8B%E5%95%8F%E9%A1%8C%EF%BC%9A%0A%0A1.%20%E6%88%AA%E5%9C%96%E5%8F%AF%E8%83%BD%E5%8C%85%E5%90%AB%E7%A7%81%E4%BA%BA%E6%96%87%E5%AD%97%E5%85%A7%E5%AE%B9%E4%B8%A6%E4%B8%8A%E5%82%B3%E8%87%B3%E5%A4%96%E9%83%A8%E4%BC%BA%E6%9C%8D%E5%99%A8%E3%80%82%0A2.%20AI%20%E5%9B%9E%E5%82%B3%E7%9A%84%E6%98%AF%E5%B0%8D%E9%9D%9E%E5%9C%96%E7%89%87%E5%85%83%E7%B4%A0%E7%9A%84%E6%8F%8F%E8%BF%B0%EF%BC%8C%E9%80%A0%E6%88%90%E4%BD%BF%E7%94%A8%E8%80%85%E5%9B%B0%E6%83%91%E3%80%82%0A3.%20%E6%B5%AA%E8%B2%BB%20API%20%E9%85%8D%E9%A1%8D%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%9C%A8%E6%93%B7%E5%8F%96%E5%89%8D%EF%BC%8C%E5%85%88%E7%A2%BA%E8%AA%8D%E8%81%9A%E7%84%A6%E5%85%83%E7%B4%A0%E7%9A%84%20accessible%20name%20%E6%88%96%20ControlType%20%E7%AC%A6%E5%90%88%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E7%9A%84%E7%89%B9%E5%BE%B5%EF%BC%88%E4%BE%8B%E5%A6%82%E5%88%A4%E6%96%B7%E6%98%AF%E5%90%A6%E5%90%AB%E6%9C%89%E5%9C%96%E7%89%87%E7%9A%84%20ControlType%EF%BC%8C%E6%88%96%E5%8F%83%E8%80%83%E6%97%A2%E6%9C%89%E7%A8%8B%E5%BC%8F%E7%A2%BC%E4%B8%AD%E8%BE%A8%E8%AD%98%E8%A8%8A%E6%81%AF%E9%A1%9E%E5%9E%8B%E7%9A%84%E9%82%8F%E8%BC%AF%EF%BC%89%EF%BC%8C%E5%A6%82%E4%B8%8B%E4%BE%8B%EF%BC%9A%0A%0A%60%60%60python%0A%23%20%E5%9C%A8%E5%8F%96%E5%BE%97%20rect%20%E4%B9%8B%E5%BE%8C%EF%BC%8C%E5%91%BC%E5%8F%AB%20_captureRegionAsPng%20%E4%B9%8B%E5%89%8D%E5%8A%A0%E5%85%A5%E9%A1%9E%E5%9E%8B%E5%88%A4%E6%96%B7%0Aname%20%3D%20rawEl.CurrentName%20or%20%22%22%0A%23%20%E5%81%87%E8%A8%AD%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%E5%9C%A8%20accessible%20name%20%E4%B8%AD%E5%8C%85%E5%90%AB%E7%89%B9%E5%AE%9A%E9%97%9C%E9%8D%B5%E5%AD%97%EF%BC%88%E9%9C%80%E4%BE%9D%E5%AF%A6%E9%9A%9B%20LINE%20UIA%20tree%20%E8%AA%BF%E6%95%B4%EF%BC%89%0Aif%20not%20_looksLikeImageMessage%28name%29%3A%0A%20%20%20%20ui.message%28_%28%22%E7%9B%AE%E5%89%8D%E8%A8%8A%E6%81%AF%E9%9D%9E%E5%9C%96%E7%89%87%E8%A8%8A%E6%81%AF%22%29%29%0A%20%20%20%20return%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Codex%22%20links%20for%20remaining%20issues.%29%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 1698-1700

Comment:
**硬編碼的 API 金鑰（安全性風險）**

`_IMAGE_DESCRIPTION_API_KEY` 被明文寫入公開的原始碼中。這會帶來以下嚴重問題：

1. **任何人都能取用此金鑰**：瀏覽 GitHub 的任何人皆可複製此金鑰並自行使用，造成配額被濫用，甚至產生計費。
2. **Google 的秘密掃描機制**：Google 會自動掃描公開 repo，發現金鑰後可能立即撤銷，導致所有使用者的此功能失效。
3. **隱私問題**：截圖會被上傳至 Google 的 API，使用者需事先知情並同意。

建議的替代方案（依優先順序）：

- **方案 A（最佳）**：完全移除內建金鑰，改由使用者在 NVDA 設定介面中輸入自己的金鑰並儲存至 `nvda.ini`。
- **方案 B（次佳）**：在 `addon/globalPlugins` 或 `installTasks.py` 提示使用者於安裝時輸入金鑰。
- **方案 C（最低限度）**：至少在功能說明中加入明確警語，說明金鑰有效期限及隱私風險，讓使用者自行替換。

```suggestion
_IMAGE_DESCRIPTION_API_KEY = ""  # 請使用者自行填入 Google AI Studio API 金鑰
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 8642-8694

Comment:
**未驗證聚焦元素是否為圖片訊息**

`script_describeImage` 會對任何聚焦的 UIA 元素（包含文字訊息、按鈕、輸入欄位等）截圖並送至 Google AI API，而非只針對圖片訊息。若使用者在非圖片訊息上按下快捷鍵，會有以下問題：

1. 截圖可能包含私人文字內容並上傳至外部伺服器。
2. AI 回傳的是對非圖片元素的描述，造成使用者困惑。
3. 浪費 API 配額。

建議在擷取前，先確認聚焦元素的 accessible name 或 ControlType 符合圖片訊息的特徵（例如判斷是否含有圖片的 ControlType，或參考既有程式碼中辨識訊息類型的邏輯），如下例：

```python
# 在取得 rect 之後，呼叫 _captureRegionAsPng 之前加入類型判斷
name = rawEl.CurrentName or ""
# 假設圖片訊息在 accessible name 中包含特定關鍵字（需依實際 LINE UIA tree 調整）
if not _looksLikeImageMessage(name):
    ui.message(_("目前訊息非圖片訊息"))
    return
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 8677-8694

Comment:
**PNG 編碼（含 zlib 壓縮）在主執行緒執行**

`_captureRegionAsPng` 包含 `zlib.compress(bytes(raw), 6)` 呼叫，這步驟對大型元素（例如 LINE 的高解析度圖片氣泡）可能需要數十毫秒，且目前在 NVDA 主執行緒同步執行，可能造成短暫卡頓。

建議將截圖與 PNG 編碼也移入背景執行緒：

```python
ui.message(_("描述圖片中，請稍候"))

import threading

_left, _top, _width, _height = left, top, width, height

def _worker():
    import wx
    pngBytes = _captureRegionAsPng(_left, _top, _width, _height)
    if not pngBytes:
        wx.CallAfter(ui.message, _("擷取圖片失敗"))
        return
    description = _describeImageBytes(pngBytes)
    if description:
        wx.CallAfter(ui.message, description)
    else:
        wx.CallAfter(ui.message, _("圖片描述失敗"))

threading.Thread(target=_worker, daemon=True).start()
```

這樣主執行緒只需取得邊界矩形即可，截圖與壓縮均在背景完成。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["新增 NVDA+Windows+I 圖片描述功能（Google AI Gemma..."](https://github.com/keyang556/linedesktopnvda/commit/5a0d34ff173123ce2f403dd1d5ed8d88f903559a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28746415)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->