### PR TITLE
Encrypt image description API key and add user configuration

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1694,16 +1694,99 @@ _currentChatRoomName = None
 _suppressAddon = False
 
 # Google AI API key used by NVDA+Windows+I image description.
-# This is an AI Studio key bundled for end-user convenience.
-_IMAGE_DESCRIPTION_API_KEY = (
-	"AQ.Ab8RN6KSiZcHSBEjCN7rZN5kP201HIwQJFGPBKdXgxShFZD7HA"
+# The bundled fallback key is stored as an XOR-obfuscated base64 blob so
+# the raw string does not appear in source form. Users can override the
+# key through the "設定圖片描述 API Key" menu item; their own key is
+# persisted with the same obfuscation under NVDA's user config directory.
+_IMAGE_DESCRIPTION_KEY_SALT = b"nvda-line-desktop-2026"
+_IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB = (
+	"Lz8eAH4VKgxUXQUxNC87BBp7ZEljUDEyXVRIJyNaL2QNBzJdMych"
 )
+_IMAGE_DESCRIPTION_USER_KEY_FILENAME = "line_desktop_image_api_key.dat"
 _IMAGE_DESCRIPTION_MODEL = "gemma-4-31b-it"
 _IMAGE_DESCRIPTION_ENDPOINT = (
 	"https://generativelanguage.googleapis.com/v1beta/models/"
 	"{model}:generateContent?key={key}"
 )
 _IMAGE_DESCRIPTION_PROMPT = "請用繁體中文簡要描述這張圖片的內容。"
+
+
+def _obfuscateImageApiKey(plain):
+	"""Reversibly obfuscate an API key string to an ASCII blob."""
+	import base64
+	data = plain.encode("utf-8")
+	salt = _IMAGE_DESCRIPTION_KEY_SALT
+	xored = bytes(b ^ salt[i % len(salt)] for i, b in enumerate(data))
+	return base64.b64encode(xored).decode("ascii")
+
+
+def _deobfuscateImageApiKey(blob):
+	"""Inverse of _obfuscateImageApiKey. Returns the plain key or None."""
+	import base64
+	if not blob:
+		return None
+	try:
+		raw = base64.b64decode(blob.encode("ascii"))
+		salt = _IMAGE_DESCRIPTION_KEY_SALT
+		plain = bytes(
+			b ^ salt[i % len(salt)] for i, b in enumerate(raw)
+		).decode("utf-8")
+	except Exception:
+		return None
+	return plain or None
+
+
+def _getImageApiKeyStorePath():
+	"""Return the filesystem path for the user-supplied API key file."""
+	try:
+		import globalVars
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_KEY_FILENAME)
+
+
+def getUserImageApiKey():
+	"""Return the plain API key previously set by the user, or None."""
+	path = _getImageApiKeyStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			blob = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user API key: {e}", exc_info=True)
+		return None
+	return _deobfuscateImageApiKey(blob)
+
+
+def setUserImageApiKey(plain):
+	"""Persist a user-supplied API key (obfuscated). Empty/None clears it."""
+	path = _getImageApiKeyStorePath()
+	if not path:
+		return False
+	try:
+		if not plain:
+			if os.path.isfile(path):
+				os.remove(path)
+			return True
+		blob = _obfuscateImageApiKey(plain)
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(blob)
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user API key: {e}", exc_info=True)
+		return False
+
+
+def _getEffectiveImageApiKey():
+	"""Return the API key to use for image description requests."""
+	userKey = getUserImageApiKey()
+	if userKey:
+		return userKey
+	return _deobfuscateImageApiKey(_IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB)
 
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")
 _NOTES_OCR_KEYWORDS = (
@@ -1811,9 +1894,13 @@ def _describeImageBytes(pngBytes, timeout=30.0):
 		import base64
 		import json
 		import urllib.request
+		apiKey = _getEffectiveImageApiKey()
+		if not apiKey:
+			log.warning("LINE: no image description API key available")
+			return None
 		url = _IMAGE_DESCRIPTION_ENDPOINT.format(
 			model=_IMAGE_DESCRIPTION_MODEL,
-			key=_IMAGE_DESCRIPTION_API_KEY,
+			key=apiKey,
 		)
 		body = {
 			"contents": [

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1788,6 +1788,7 @@ def _getEffectiveImageApiKey():
 		return userKey
 	return _deobfuscateImageApiKey(_IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB)
 
+
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")
 _NOTES_OCR_KEYWORDS = (
 	"記事本", "相簿", "已儲存",

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1694,11 +1694,12 @@ _currentChatRoomName = None
 _suppressAddon = False
 
 # Google AI API key used by NVDA+Windows+I image description.
-# The bundled fallback key is stored as an XOR-obfuscated base64 blob so
-# the raw string does not appear in source form. Users can override the
-# key through the "設定圖片描述 API Key" menu item; their own key is
-# persisted with the same obfuscation under NVDA's user config directory.
-_IMAGE_DESCRIPTION_KEY_SALT = b"nvda-line-desktop-2026"
+# The bundled convenience key is base64-encoded to avoid being trivially
+# grep-able as a plaintext string. It is NOT a secret: this is an open-source
+# addon and any determined reader can recover it. Its purpose is to spare
+# casual end-users from having to obtain their own key. Users can override
+# it at any time through the "設定圖片描述 API Key" menu item; their key
+# is persisted (also encoded) under NVDA's user config directory.
 _IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB = (
 	"Lz8eAH4VKgxUXQUxNC87BBp7ZEljUDEyXVRIJyNaL2QNBzJdMych"
 )
@@ -1712,25 +1713,20 @@ _IMAGE_DESCRIPTION_PROMPT = "請用繁體中文簡要描述這張圖片的內容
 
 
 def _obfuscateImageApiKey(plain):
-	"""Reversibly obfuscate an API key string to an ASCII blob."""
 	import base64
-	data = plain.encode("utf-8")
-	salt = _IMAGE_DESCRIPTION_KEY_SALT
-	xored = bytes(b ^ salt[i % len(salt)] for i, b in enumerate(data))
+	_s = b"nvda-line-desktop-2026"
+	xored = bytes(b ^ _s[i % len(_s)] for i, b in enumerate(plain.encode("utf-8")))
 	return base64.b64encode(xored).decode("ascii")
 
 
 def _deobfuscateImageApiKey(blob):
-	"""Inverse of _obfuscateImageApiKey. Returns the plain key or None."""
 	import base64
 	if not blob:
 		return None
 	try:
+		_s = b"nvda-line-desktop-2026"
 		raw = base64.b64decode(blob.encode("ascii"))
-		salt = _IMAGE_DESCRIPTION_KEY_SALT
-		plain = bytes(
-			b ^ salt[i % len(salt)] for i, b in enumerate(raw)
-		).decode("utf-8")
+		plain = bytes(b ^ _s[i % len(_s)] for i, b in enumerate(raw)).decode("utf-8")
 	except Exception:
 		return None
 	return plain or None

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -555,6 +555,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			if dlg.ShowModal() != wx.ID_OK:
 				return
 			newKey = dlg.GetValue().strip()
+		except Exception as e:
+			log.warning(f"LINE: image API key dialog error: {e}", exc_info=True)
+			ui.message(_("設定 API Key 時發生錯誤"))
+			return
 		finally:
 			dlg.Destroy()
 

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -206,6 +206,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				# Translators: Menu item for toggling Qt accessibility env var
 				_("切換 Qt 無障礙環境變數(&Q)"),
 			)
+			self._imageApiKeyItem = self._lineSubMenu.Append(
+				wx.ID_ANY,
+				# Translators: Menu item for setting the image-description API key
+				_("設定圖片描述 API Key(&I)"),
+			)
 
 			# Bind events
 			gui.mainFrame.sysTrayIcon.Bind(
@@ -252,6 +257,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			)
 			gui.mainFrame.sysTrayIcon.Bind(
 				wx.EVT_MENU, self._onToggleQtAccessible, self._qtAccessibleItem
+			)
+			gui.mainFrame.sysTrayIcon.Bind(
+				wx.EVT_MENU, self._onSetImageApiKey, self._imageApiKeyItem
 			)
 
 			# Add the submenu to NVDA's Tools menu
@@ -516,6 +524,47 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				ui.message(_("已設定 QT_ACCESSIBILITY=1，重啟 LINE 後生效"))
 			else:
 				ui.message(_("設定 QT_ACCESSIBILITY 環境變數失敗"))
+
+	def _onSetImageApiKey(self, evt):
+		wx.CallAfter(self._doSetImageApiKey)
+
+	def _doSetImageApiKey(self):
+		import ui
+		try:
+			from appModules.line import (
+				getUserImageApiKey, setUserImageApiKey,
+			)
+		except Exception as e:
+			log.warning(f"LINE: cannot load image API key helpers: {e}", exc_info=True)
+			ui.message(_("無法載入 API Key 設定"))
+			return
+
+		current = getUserImageApiKey() or ""
+		dlg = wx.TextEntryDialog(
+			gui.mainFrame,
+			# Translators: Prompt shown in the image-description API key dialog
+			_(
+				"請輸入您自己的 Google AI API Key。\n"
+				"留空則使用預設作者提供的金鑰。"
+			),
+			# Translators: Title of the image-description API key dialog
+			_("LINE Desktop - 圖片描述 API Key"),
+			current,
+		)
+		try:
+			if dlg.ShowModal() != wx.ID_OK:
+				return
+			newKey = dlg.GetValue().strip()
+		finally:
+			dlg.Destroy()
+
+		if setUserImageApiKey(newKey):
+			if newKey:
+				ui.message(_("已儲存自訂 API Key"))
+			else:
+				ui.message(_("已清除，將使用預設 API Key"))
+		else:
+			ui.message(_("儲存 API Key 失敗"))
 
 	def terminate(self, *args, **kwargs):
 		self._removeToolsMenu()


### PR DESCRIPTION
## Summary
- Encrypt bundled API key with XOR+base64 obfuscation (not plaintext in source)
- Add user configuration UI via "設定圖片描述 API Key" menu item
- Users can input custom API key; stored persistently (also obfuscated)
- Fall back to bundled default if user key not set

## Implementation details
- Obfuscation uses XOR with salt `nvda-line-desktop-2026` + base64 encoding
- User key stored at `<NVDA configPath>/line_desktop_image_api_key.dat`
- Helper functions: `getUserImageApiKey()`, `setUserImageApiKey()`, `_getEffectiveImageApiKey()`
- Menu dialog in lineDesktopHelper.py allows enter/clear custom key

## Test plan
- [ ] Verify image description works with default bundled key
- [ ] Set custom API key via menu → verify it's used
- [ ] Clear custom key → verify fallback to bundled default works
- [ ] Verify obfuscated blob is not readable as plaintext in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 為圖片描述功能新增使用者自訂 API Key 的設定 UI，並將原本以明文存放的 bundled key 改為 XOR+base64 混淆格式。使用者可透過系統匣選單輸入自己的 Google AI API Key，金鑰以相同混淆方式持久化至 NVDA 設定目錄；若未設定則 fallback 至內建預設金鑰。

**主要變更：**
- `line.py`：新增 `_obfuscateImageApiKey` / `_deobfuscateImageApiKey` / `_getEffectiveImageApiKey` 等輔助函式，及讀寫使用者金鑰檔案的 `getUserImageApiKey` / `setUserImageApiKey`；`_describeImageBytes` 改用 `_getEffectiveImageApiKey()` 取得金鑰。
- `lineDesktopHelper.py`：新增「設定圖片描述 API Key」選單項目與 `_doSetImageApiKey` 對話框流程。

**本輪新發現：**
- `_deobfuscateImageApiKey` 的例外被靜默吞噬，缺少 debug log，未來診斷金鑰解碼失敗時不易追蹤。

<h3>Confidence Score: 4/5</h3>

此 PR 功能正確、控制流完整，前幾輪的核心問題已被作者明確知悉並在程式碼注解中說明，可安全合併。

使用者金鑰管理的讀寫邏輯正確，try/finally 確保對話框資源一定會被釋放，fallback 機制完整。安全性劇場問題已在注解中坦承，不構成額外風險。僅剩 `_deobfuscateImageApiKey` 缺少 debug log 屬 P2 層級的建議，不阻擋合併。

無需特別關注的檔案；`addon/appModules/line.py` 中的 `_deobfuscateImageApiKey` 可考慮加入 debug log。

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 XOR+base64 混淆輔助函式、使用者金鑰讀寫工具，及 `_getEffectiveImageApiKey()` 整合預設與使用者金鑰；`_deobfuscateImageApiKey` 的 except 區塊缺少 debug log，其餘邏輯正確。 |
| addon/globalPlugins/lineDesktopHelper.py | 新增「設定圖片描述 API Key」選單項目及對應對話框流程；try/except/finally 結構正確，對話框一定會被 Destroy()，整體實作無重大問題。 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Menu as 系統匣選單
    participant Dialog as wx.TextEntryDialog
    participant Helper as lineDesktopHelper.py
    participant LineModule as line.py
    participant Disk as 設定檔 (.dat)
    participant API as Google AI API

    User->>Menu: 點選「設定圖片描述 API Key」
    Menu->>Helper: _onSetImageApiKey(evt)
    Helper->>Helper: wx.CallAfter(_doSetImageApiKey)
    Helper->>LineModule: getUserImageApiKey()
    LineModule->>Disk: 讀取 line_desktop_image_api_key.dat
    Disk-->>LineModule: 混淆後 blob
    LineModule-->>Helper: 解混淆後的明文 key（或 None）
    Helper->>Dialog: ShowModal(current_key)
    User->>Dialog: 輸入新金鑰 / 留空 / 取消
    Dialog-->>Helper: ID_OK + newKey（或 ID_CANCEL）
    Helper->>LineModule: setUserImageApiKey(newKey)
    LineModule->>LineModule: _obfuscateImageApiKey(newKey)
    LineModule->>Disk: 寫入混淆後 blob（或刪除檔案）
    Disk-->>LineModule: 成功 / 失敗
    LineModule-->>Helper: True / False
    Helper-->>User: ui.message(結果訊息)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `addon/appModules/line.py`, line 1932-1936 ([link](https://github.com/keyang556/linedesktopnvda/blob/953c0c0365790f9911d1a7e410d7cecb45c2f490/addon/appModules/line.py#L1932-L1936)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **API 金鑰可能透過例外日誌洩露**

   `url` 字串將 API 金鑰以查詢參數形式內嵌於網址中。目前 `exc_info=True` 會將完整的例外追蹤資訊寫入 NVDA 日誌，若 `urllib` 在例外物件中保留了完整請求 URL（例如 `HTTPError.url`），金鑰便可能出現在日誌檔中。

   建議僅記錄例外類型而非完整追蹤資訊，以避免意外洩露：

   ```python
   		log.warning(
   			"LINE: image description request failed: %s",
   			type(e).__name__,
   		)
   ```

   或在構建 URL 前，先將金鑰遮蔽為 `****` 再用於日誌輸出。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: addon/appModules/line.py
   Line: 1932-1936

   Comment:
   **API 金鑰可能透過例外日誌洩露**

   `url` 字串將 API 金鑰以查詢參數形式內嵌於網址中。目前 `exc_info=True` 會將完整的例外追蹤資訊寫入 NVDA 日誌，若 `urllib` 在例外物件中保留了完整請求 URL（例如 `HTTPError.url`），金鑰便可能出現在日誌檔中。

   建議僅記錄例外類型而非完整追蹤資訊，以避免意外洩露：

   ```python
   		log.warning(
   			"LINE: image description request failed: %s",
   			type(e).__name__,
   		)
   ```

   或在構建 URL 前，先將金鑰遮蔽為 `****` 再用於日誌輸出。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%201932-1936%0A%0AComment%3A%0A**API%20%E9%87%91%E9%91%B0%E5%8F%AF%E8%83%BD%E9%80%8F%E9%81%8E%E4%BE%8B%E5%A4%96%E6%97%A5%E8%AA%8C%E6%B4%A9%E9%9C%B2**%0A%0A%60url%60%20%E5%AD%97%E4%B8%B2%E5%B0%87%20API%20%E9%87%91%E9%91%B0%E4%BB%A5%E6%9F%A5%E8%A9%A2%E5%8F%83%E6%95%B8%E5%BD%A2%E5%BC%8F%E5%85%A7%E5%B5%8C%E6%96%BC%E7%B6%B2%E5%9D%80%E4%B8%AD%E3%80%82%E7%9B%AE%E5%89%8D%20%60exc_info%3DTrue%60%20%E6%9C%83%E5%B0%87%E5%AE%8C%E6%95%B4%E7%9A%84%E4%BE%8B%E5%A4%96%E8%BF%BD%E8%B9%A4%E8%B3%87%E8%A8%8A%E5%AF%AB%E5%85%A5%20NVDA%20%E6%97%A5%E8%AA%8C%EF%BC%8C%E8%8B%A5%20%60urllib%60%20%E5%9C%A8%E4%BE%8B%E5%A4%96%E7%89%A9%E4%BB%B6%E4%B8%AD%E4%BF%9D%E7%95%99%E4%BA%86%E5%AE%8C%E6%95%B4%E8%AB%8B%E6%B1%82%20URL%EF%BC%88%E4%BE%8B%E5%A6%82%20%60HTTPError.url%60%EF%BC%89%EF%BC%8C%E9%87%91%E9%91%B0%E4%BE%BF%E5%8F%AF%E8%83%BD%E5%87%BA%E7%8F%BE%E5%9C%A8%E6%97%A5%E8%AA%8C%E6%AA%94%E4%B8%AD%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%83%85%E8%A8%98%E9%8C%84%E4%BE%8B%E5%A4%96%E9%A1%9E%E5%9E%8B%E8%80%8C%E9%9D%9E%E5%AE%8C%E6%95%B4%E8%BF%BD%E8%B9%A4%E8%B3%87%E8%A8%8A%EF%BC%8C%E4%BB%A5%E9%81%BF%E5%85%8D%E6%84%8F%E5%A4%96%E6%B4%A9%E9%9C%B2%EF%BC%9A%0A%0A%60%60%60python%0A%09%09log.warning%28%0A%09%09%09%22LINE%3A%20image%20description%20request%20failed%3A%20%25s%22%2C%0A%09%09%09type%28e%29.__name__%2C%0A%09%09%29%0A%60%60%60%0A%0A%E6%88%96%E5%9C%A8%E6%A7%8B%E5%BB%BA%20URL%20%E5%89%8D%EF%BC%8C%E5%85%88%E5%B0%87%E9%87%91%E9%91%B0%E9%81%AE%E8%94%BD%E7%82%BA%20%60****%60%20%E5%86%8D%E7%94%A8%E6%96%BC%E6%97%A5%E8%AA%8C%E8%BC%B8%E5%87%BA%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=keyang556%2Flinedesktopnvda&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Fpractical-chaplygin-a9980b%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fpractical-chaplygin-a9980b%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%201932-1936%0A%0AComment%3A%0A**API%20%E9%87%91%E9%91%B0%E5%8F%AF%E8%83%BD%E9%80%8F%E9%81%8E%E4%BE%8B%E5%A4%96%E6%97%A5%E8%AA%8C%E6%B4%A9%E9%9C%B2**%0A%0A%60url%60%20%E5%AD%97%E4%B8%B2%E5%B0%87%20API%20%E9%87%91%E9%91%B0%E4%BB%A5%E6%9F%A5%E8%A9%A2%E5%8F%83%E6%95%B8%E5%BD%A2%E5%BC%8F%E5%85%A7%E5%B5%8C%E6%96%BC%E7%B6%B2%E5%9D%80%E4%B8%AD%E3%80%82%E7%9B%AE%E5%89%8D%20%60exc_info%3DTrue%60%20%E6%9C%83%E5%B0%87%E5%AE%8C%E6%95%B4%E7%9A%84%E4%BE%8B%E5%A4%96%E8%BF%BD%E8%B9%A4%E8%B3%87%E8%A8%8A%E5%AF%AB%E5%85%A5%20NVDA%20%E6%97%A5%E8%AA%8C%EF%BC%8C%E8%8B%A5%20%60urllib%60%20%E5%9C%A8%E4%BE%8B%E5%A4%96%E7%89%A9%E4%BB%B6%E4%B8%AD%E4%BF%9D%E7%95%99%E4%BA%86%E5%AE%8C%E6%95%B4%E8%AB%8B%E6%B1%82%20URL%EF%BC%88%E4%BE%8B%E5%A6%82%20%60HTTPError.url%60%EF%BC%89%EF%BC%8C%E9%87%91%E9%91%B0%E4%BE%BF%E5%8F%AF%E8%83%BD%E5%87%BA%E7%8F%BE%E5%9C%A8%E6%97%A5%E8%AA%8C%E6%AA%94%E4%B8%AD%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%83%85%E8%A8%98%E9%8C%84%E4%BE%8B%E5%A4%96%E9%A1%9E%E5%9E%8B%E8%80%8C%E9%9D%9E%E5%AE%8C%E6%95%B4%E8%BF%BD%E8%B9%A4%E8%B3%87%E8%A8%8A%EF%BC%8C%E4%BB%A5%E9%81%BF%E5%85%8D%E6%84%8F%E5%A4%96%E6%B4%A9%E9%9C%B2%EF%BC%9A%0A%0A%60%60%60python%0A%09%09log.warning%28%0A%09%09%09%22LINE%3A%20image%20description%20request%20failed%3A%20%25s%22%2C%0A%09%09%09type%28e%29.__name__%2C%0A%09%09%29%0A%60%60%60%0A%0A%E6%88%96%E5%9C%A8%E6%A7%8B%E5%BB%BA%20URL%20%E5%89%8D%EF%BC%8C%E5%85%88%E5%B0%87%E9%87%91%E9%91%B0%E9%81%AE%E8%94%BD%E7%82%BA%20%60****%60%20%E5%86%8D%E7%94%A8%E6%96%BC%E6%97%A5%E8%AA%8C%E8%BC%B8%E5%87%BA%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A1722-1732%0A**%60_deobfuscateImageApiKey%60%20%E9%9D%9C%E9%BB%98%E5%90%9E%E5%99%AC%E4%BE%8B%E5%A4%96%EF%BC%8C%E7%84%A1%E8%A8%BA%E6%96%B7%E8%A8%98%E9%8C%84**%0A%0A%E8%8B%A5%E4%BD%BF%E7%94%A8%E8%80%85%E5%84%B2%E5%AD%98%E7%9A%84%E9%87%91%E9%91%B0%E6%AA%94%E6%A1%88%E9%81%AD%E5%88%B0%E6%90%8D%E6%AF%80%EF%BC%88%E4%BE%8B%E5%A6%82%E5%AD%97%E5%85%83%E9%9B%86%E5%95%8F%E9%A1%8C%E6%88%96%E6%88%AA%E6%96%B7%EF%BC%89%EF%BC%8C%E6%88%96%E9%A0%90%E8%A8%AD%20blob%20%E5%9C%A8%E6%9C%AA%E4%BE%86%E6%9B%B4%E6%96%B0%E6%99%82%E5%9B%A0%E6%94%B9%E5%8B%95%E7%94%A2%E7%94%9F%20base64%20%E9%8C%AF%E8%AA%A4%EF%BC%8C%E6%AD%A4%E5%87%BD%E5%BC%8F%E6%9C%83%E9%9D%9C%E9%BB%98%E5%9B%9E%E5%82%B3%20%60None%60%EF%BC%8C%E8%80%8C%E4%B8%8D%E6%9C%83%E7%95%99%E4%B8%8B%E4%BB%BB%E4%BD%95%20log%20%E8%A8%8A%E6%81%AF%E3%80%82%0A%0A%E5%94%AF%E4%B8%80%E7%9A%84%E9%8C%AF%E8%AA%A4%E7%B7%9A%E7%B4%A2%E6%98%AF%20%60_describeImageBytes%60%20%E4%B8%AD%E7%9A%84%20%60log.warning%28%22LINE%3A%20no%20image%20description%20API%20key%20available%22%29%60%EF%BC%8C%E4%BD%86%E9%80%99%E7%84%A1%E6%B3%95%E5%8D%80%E5%88%86%E3%80%8C%E9%87%91%E9%91%B0%E8%A7%A3%E7%A2%BC%E5%A4%B1%E6%95%97%E3%80%8D%E8%88%87%E3%80%8C%E9%87%91%E9%91%B0%E7%A2%BA%E5%AF%A6%E6%9C%AA%E8%A8%AD%E5%AE%9A%E3%80%8D%E5%85%A9%E7%A8%AE%E6%83%85%E6%B3%81%EF%BC%8C%E5%A2%9E%E5%8A%A0%E4%BA%86%E9%99%A4%E9%8C%AF%E9%9B%A3%E5%BA%A6%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%9C%A8%20%60except%60%20%E5%AD%90%E5%8F%A5%E4%B8%AD%E5%8A%A0%E5%85%A5%20%60log.debug%28...%29%60%20%E4%BB%A5%E8%A8%98%E9%8C%84%E8%A7%A3%E7%A2%BC%E5%A4%B1%E6%95%97%E7%9A%84%E5%8E%9F%E5%9B%A0%EF%BC%8C%E6%96%B9%E4%BE%BF%E6%9C%AA%E4%BE%86%E8%BF%BD%E8%B9%A4%E5%95%8F%E9%A1%8C%EF%BC%9A%0A%0A%60%60%60suggestion%0Adef%20_deobfuscateImageApiKey%28blob%29%3A%0A%09import%20base64%0A%09if%20not%20blob%3A%0A%09%09return%20None%0A%09try%3A%0A%09%09_s%20%3D%20b%22nvda-line-desktop-2026%22%0A%09%09raw%20%3D%20base64.b64decode%28blob.encode%28%22ascii%22%29%29%0A%09%09plain%20%3D%20bytes%28b%20%5E%20_s%5Bi%20%25%20len%28_s%29%5D%20for%20i%2C%20b%20in%20enumerate%28raw%29%29.decode%28%22utf-8%22%29%0A%09except%20Exception%20as%20e%3A%0A%09%09log.debug%28f%22LINE%3A%20failed%20to%20deobfuscate%20API%20key%20blob%3A%20%7Be%7D%22%2C%20exc_info%3DTrue%29%0A%09%09return%20None%0A%09return%20plain%20or%20None%0A%60%60%60%0A%0A&repo=keyang556%2Flinedesktopnvda&pr=57&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Fpractical-chaplygin-a9980b%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fpractical-chaplygin-a9980b%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2Fline.py%3A1722-1732%0A**%60_deobfuscateImageApiKey%60%20%E9%9D%9C%E9%BB%98%E5%90%9E%E5%99%AC%E4%BE%8B%E5%A4%96%EF%BC%8C%E7%84%A1%E8%A8%BA%E6%96%B7%E8%A8%98%E9%8C%84**%0A%0A%E8%8B%A5%E4%BD%BF%E7%94%A8%E8%80%85%E5%84%B2%E5%AD%98%E7%9A%84%E9%87%91%E9%91%B0%E6%AA%94%E6%A1%88%E9%81%AD%E5%88%B0%E6%90%8D%E6%AF%80%EF%BC%88%E4%BE%8B%E5%A6%82%E5%AD%97%E5%85%83%E9%9B%86%E5%95%8F%E9%A1%8C%E6%88%96%E6%88%AA%E6%96%B7%EF%BC%89%EF%BC%8C%E6%88%96%E9%A0%90%E8%A8%AD%20blob%20%E5%9C%A8%E6%9C%AA%E4%BE%86%E6%9B%B4%E6%96%B0%E6%99%82%E5%9B%A0%E6%94%B9%E5%8B%95%E7%94%A2%E7%94%9F%20base64%20%E9%8C%AF%E8%AA%A4%EF%BC%8C%E6%AD%A4%E5%87%BD%E5%BC%8F%E6%9C%83%E9%9D%9C%E9%BB%98%E5%9B%9E%E5%82%B3%20%60None%60%EF%BC%8C%E8%80%8C%E4%B8%8D%E6%9C%83%E7%95%99%E4%B8%8B%E4%BB%BB%E4%BD%95%20log%20%E8%A8%8A%E6%81%AF%E3%80%82%0A%0A%E5%94%AF%E4%B8%80%E7%9A%84%E9%8C%AF%E8%AA%A4%E7%B7%9A%E7%B4%A2%E6%98%AF%20%60_describeImageBytes%60%20%E4%B8%AD%E7%9A%84%20%60log.warning%28%22LINE%3A%20no%20image%20description%20API%20key%20available%22%29%60%EF%BC%8C%E4%BD%86%E9%80%99%E7%84%A1%E6%B3%95%E5%8D%80%E5%88%86%E3%80%8C%E9%87%91%E9%91%B0%E8%A7%A3%E7%A2%BC%E5%A4%B1%E6%95%97%E3%80%8D%E8%88%87%E3%80%8C%E9%87%91%E9%91%B0%E7%A2%BA%E5%AF%A6%E6%9C%AA%E8%A8%AD%E5%AE%9A%E3%80%8D%E5%85%A9%E7%A8%AE%E6%83%85%E6%B3%81%EF%BC%8C%E5%A2%9E%E5%8A%A0%E4%BA%86%E9%99%A4%E9%8C%AF%E9%9B%A3%E5%BA%A6%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E5%9C%A8%20%60except%60%20%E5%AD%90%E5%8F%A5%E4%B8%AD%E5%8A%A0%E5%85%A5%20%60log.debug%28...%29%60%20%E4%BB%A5%E8%A8%98%E9%8C%84%E8%A7%A3%E7%A2%BC%E5%A4%B1%E6%95%97%E7%9A%84%E5%8E%9F%E5%9B%A0%EF%BC%8C%E6%96%B9%E4%BE%BF%E6%9C%AA%E4%BE%86%E8%BF%BD%E8%B9%A4%E5%95%8F%E9%A1%8C%EF%BC%9A%0A%0A%60%60%60suggestion%0Adef%20_deobfuscateImageApiKey%28blob%29%3A%0A%09import%20base64%0A%09if%20not%20blob%3A%0A%09%09return%20None%0A%09try%3A%0A%09%09_s%20%3D%20b%22nvda-line-desktop-2026%22%0A%09%09raw%20%3D%20base64.b64decode%28blob.encode%28%22ascii%22%29%29%0A%09%09plain%20%3D%20bytes%28b%20%5E%20_s%5Bi%20%25%20len%28_s%29%5D%20for%20i%2C%20b%20in%20enumerate%28raw%29%29.decode%28%22utf-8%22%29%0A%09except%20Exception%20as%20e%3A%0A%09%09log.debug%28f%22LINE%3A%20failed%20to%20deobfuscate%20API%20key%20blob%3A%20%7Be%7D%22%2C%20exc_info%3DTrue%29%0A%09%09return%20None%0A%09return%20plain%20or%20None%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 1722-1732

Comment:
**`_deobfuscateImageApiKey` 靜默吞噬例外，無診斷記錄**

若使用者儲存的金鑰檔案遭到損毀（例如字元集問題或截斷），或預設 blob 在未來更新時因改動產生 base64 錯誤，此函式會靜默回傳 `None`，而不會留下任何 log 訊息。

唯一的錯誤線索是 `_describeImageBytes` 中的 `log.warning("LINE: no image description API key available")`，但這無法區分「金鑰解碼失敗」與「金鑰確實未設定」兩種情況，增加了除錯難度。

建議在 `except` 子句中加入 `log.debug(...)` 以記錄解碼失敗的原因，方便未來追蹤問題：

```suggestion
def _deobfuscateImageApiKey(blob):
	import base64
	if not blob:
		return None
	try:
		_s = b"nvda-line-desktop-2026"
		raw = base64.b64decode(blob.encode("ascii"))
		plain = bytes(b ^ _s[i % len(_s)] for i, b in enumerate(raw)).decode("utf-8")
	except Exception as e:
		log.debug(f"LINE: failed to deobfuscate API key blob: {e}", exc_info=True)
		return None
	return plain or None
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Address review comments: remove module-l..."](https://github.com/keyang556/linedesktopnvda/commit/2e88c5b0a4ac48aedf5850bb10be507ba8d52388) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28882350)</sub>

<!-- /greptile_comment -->