### PR TITLE
Add model selection dropdown for image description

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1696,7 +1696,26 @@ _IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB = (
 	"g+Ku1l+8YmbpO4/JPwy+ZyMlZw4Nfm9gO5bbn8K/vPkz7VFoMRpiFsx2hgfKpUqbxmWqQGo2h8Ph7YjZljEEFkmc3+HlxuE="
 )
 _IMAGE_DESCRIPTION_USER_KEY_FILENAME = "line_desktop_image_api_key.dat"
-_IMAGE_DESCRIPTION_MODEL = "gemma-4-26b-a4b-it"
+_IMAGE_DESCRIPTION_USER_MODEL_FILENAME = "line_desktop_image_model.txt"
+# Default model used when the user has not picked one in the settings panel.
+_IMAGE_DESCRIPTION_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
+# Models exposed in the settings panel dropdown. The order here is the order
+# the user sees. Strings are the actual model IDs sent to the API endpoint.
+# NOTE: "gemma-3-27b-it" maps to the UI label "Gemma 3 27B" — confirm the
+# exact API model ID before trusting it for production use.
+_IMAGE_DESCRIPTION_AVAILABLE_MODELS = (
+	"gemini-3-flash-preview",
+	"gemini-3.1-flash-lite-preview",
+	"gemini-flash-latest",
+	"gemini-flash-lite-latest",
+	"gemini-2.5-flash",
+	"gemini-2.5-flash-lite",
+	"gemini-2.0-flash",
+	"gemini-2.0-flash-lite",
+	"gemma-4-26b-a4b-it",
+	"gemma-4-31b-it",
+	"gemma-3-27b-it",
+)
 _IMAGE_DESCRIPTION_ENDPOINT = (
 	"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
 )
@@ -1840,6 +1859,64 @@ def _getEffectiveImageApiKey():
 	return _cachedEffectiveImageApiKey
 
 
+def _getImageModelStorePath():
+	"""Return the filesystem path for the user-selected model preference."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_MODEL_FILENAME)
+
+
+def getUserImageModel():
+	"""Return the model ID previously chosen by the user, or None."""
+	path = _getImageModelStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			value = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user image model: {e}", exc_info=True)
+		return None
+	if not value:
+		return None
+	if value not in _IMAGE_DESCRIPTION_AVAILABLE_MODELS:
+		log.debug(f"LINE: stored image model {value!r} is not in the allowed list")
+		return None
+	return value
+
+
+def setUserImageModel(name):
+	"""Persist a user-selected model. Empty/None or the default clears the file."""
+	path = _getImageModelStorePath()
+	if not path:
+		return False
+	try:
+		if not name or name == _IMAGE_DESCRIPTION_DEFAULT_MODEL:
+			if os.path.isfile(path):
+				os.remove(path)
+			return True
+		if name not in _IMAGE_DESCRIPTION_AVAILABLE_MODELS:
+			log.warning(f"LINE: refusing to save unknown image model {name!r}")
+			return False
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(name)
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user image model: {e}", exc_info=True)
+		return False
+
+
+def _getEffectiveImageModel():
+	"""Return the model ID to use for image description requests."""
+	return getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
+
+
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")
 _NOTES_OCR_KEYWORDS = (
 	"記事本",
@@ -1962,7 +2039,7 @@ def _describeImageBytes(pngBytes, timeout=30.0):
 			log.warning("LINE: no image description API key available")
 			return None, _("未設定 API Key")
 		url = _IMAGE_DESCRIPTION_ENDPOINT.format(
-			model=_IMAGE_DESCRIPTION_MODEL,
+			model=_getEffectiveImageModel(),
 			key=apiKey,
 		)
 		body = {

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1701,8 +1701,12 @@ _IMAGE_DESCRIPTION_USER_MODEL_FILENAME = "line_desktop_image_model.txt"
 _IMAGE_DESCRIPTION_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
 # Models exposed in the settings panel dropdown. The order here is the order
 # the user sees. Strings are the actual model IDs sent to the API endpoint.
-# NOTE: "gemma-3-27b-it" maps to the UI label "Gemma 3 27B" — confirm the
-# exact API model ID before trusting it for production use.
+# VERIFY all IDs against: GET https://generativelanguage.googleapis.com/v1beta/models
+# Notable uncertainties: "gemini-3-flash-preview" (vs "gemini-3.1-…" naming style),
+# "gemini-flash-latest"/"gemini-flash-lite-latest" (versionless aliases),
+# "gemini-2.5-flash-lite" (may need a "-preview" suffix),
+# "gemma-4-26b-a4b-it"/"gemma-4-31b-it" (availability in Generative Language API),
+# "gemma-3-27b-it" (Gemma 3 27B — confirm exact API model ID).
 _IMAGE_DESCRIPTION_AVAILABLE_MODELS = (
 	"gemini-3-flash-preview",
 	"gemini-3.1-flash-lite-preview",
@@ -1891,8 +1895,12 @@ def getUserImageModel():
 	return value
 
 
+_cachedEffectiveImageModel = _NOT_COMPUTED
+
+
 def setUserImageModel(name):
 	"""Persist a user-selected model. Empty/None or the default clears the file."""
+	global _cachedEffectiveImageModel
 	path = _getImageModelStorePath()
 	if not path:
 		return False
@@ -1900,12 +1908,14 @@ def setUserImageModel(name):
 		if not name or name == _IMAGE_DESCRIPTION_DEFAULT_MODEL:
 			if os.path.isfile(path):
 				os.remove(path)
+			_cachedEffectiveImageModel = _IMAGE_DESCRIPTION_DEFAULT_MODEL
 			return True
 		if name not in _IMAGE_DESCRIPTION_AVAILABLE_MODELS:
 			log.warning(f"LINE: refusing to save unknown image model {name!r}")
 			return False
 		with open(path, "w", encoding="utf-8") as f:
 			f.write(name)
+		_cachedEffectiveImageModel = name
 		return True
 	except Exception as e:
 		log.warning(f"LINE: failed to save user image model: {e}", exc_info=True)
@@ -1913,8 +1923,11 @@ def setUserImageModel(name):
 
 
 def _getEffectiveImageModel():
-	"""Return the model ID to use for image description requests."""
-	return getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
+	"""Return the cached model ID; lazily resolved from disk on first call."""
+	global _cachedEffectiveImageModel
+	if _cachedEffectiveImageModel is _NOT_COMPUTED:
+		_cachedEffectiveImageModel = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
+	return _cachedEffectiveImageModel
 
 
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -113,6 +113,24 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		self._apiKeyText = sHelper.addLabeledControl(apiLabel, wx.TextCtrl)
 		self._apiKeyText.SetValue(self._loadCurrentApiKey())
 
+		self._modelChoices, defaultModel, currentModel = self._loadModelOptions()
+		# Translators: Dropdown label for selecting the image-description model
+		modelLabel = _("圖片描述模型 (&M)")
+		self._modelChoice = sHelper.addLabeledControl(
+			modelLabel,
+			wx.Choice,
+			choices=list(self._modelChoices),
+		)
+		try:
+			selectIndex = self._modelChoices.index(currentModel)
+		except ValueError:
+			try:
+				selectIndex = self._modelChoices.index(defaultModel)
+			except ValueError:
+				selectIndex = 0
+		if self._modelChoices:
+			self._modelChoice.SetSelection(selectIndex)
+
 	def _loadCurrentApiKey(self):
 		try:
 			from appModules.line import getUserImageApiKey
@@ -121,6 +139,25 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		except Exception:
 			log.debug("LINE: cannot load user API key for settings panel", exc_info=True)
 			return ""
+
+	def _loadModelOptions(self):
+		"""Return (choices_tuple, default_model_id, currently_selected_model_id)."""
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
+				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
+				getUserImageModel,
+			)
+
+			current = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
+			return (
+				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
+				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
+				current,
+			)
+		except Exception:
+			log.debug("LINE: cannot load image model options", exc_info=True)
+			return ((), "", "")
 
 	def onSave(self):
 		# Qt accessibility env var
@@ -162,6 +199,29 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				_("LINE Desktop - 設定錯誤"),
 				wx.OK | wx.ICON_ERROR,
 				self,
+			)
+
+		# Image description model
+		try:
+			from appModules.line import getUserImageModel, setUserImageModel
+
+			selectedIndex = self._modelChoice.GetSelection()
+			if selectedIndex != wx.NOT_FOUND and self._modelChoices:
+				newModel = self._modelChoices[selectedIndex]
+				currentModel = getUserImageModel() or ""
+				if newModel != currentModel:
+					if not setUserImageModel(newModel):
+						gui.messageBox(
+							# Translators: Error shown when saving the image model fails
+							_("儲存圖片描述模型失敗，請重試。"),
+							_("LINE Desktop - 設定錯誤"),
+							wx.OK | wx.ICON_ERROR,
+							self,
+						)
+		except Exception:
+			log.warning(
+				"LINE: cannot load image model helpers from settings panel",
+				exc_info=True,
 			)
 
 

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -203,12 +203,16 @@ class LineDesktopSettingsPanel(SettingsPanel):
 
 		# Image description model
 		try:
-			from appModules.line import getUserImageModel, setUserImageModel
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
+				getUserImageModel,
+				setUserImageModel,
+			)
 
 			selectedIndex = self._modelChoice.GetSelection()
 			if selectedIndex != wx.NOT_FOUND and self._modelChoices:
 				newModel = self._modelChoices[selectedIndex]
-				currentModel = getUserImageModel() or ""
+				currentModel = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
 				if newModel != currentModel:
 					if not setUserImageModel(newModel):
 						gui.messageBox(

--- a/buildVars.py
+++ b/buildVars.py
@@ -1,0 +1,72 @@
+# Build customizations
+# Change this file instead of sconstruct or manifest files, whenever possible.
+
+from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries
+
+# Since some strings in `addon_info` are translatable,
+# we need to include them in the .po files.
+# Gettext recognizes only strings given as parameters to the `_` function.
+# To avoid initializing translations in this module we simply import a "fake" `_` function
+# which returns whatever is given to it as an argument.
+from site_scons.site_tools.NVDATool.utils import _
+
+
+# Add-on information variables
+addon_info = AddonInfo(
+	# add-on Name/identifier, internal for NVDA
+	addon_name="lineDesktop",
+	# Add-on summary/title, usually the user visible name of the add-on
+	# Translators: Summary/title for this add-on
+	# to be shown on installation and add-on information found in add-on store
+	addon_summary=_("LINE Desktop Accessibility"),
+	# Add-on description
+	# Translators: Long description to be shown for this add-on on add-on information from add-on store
+	addon_description=_("""Enhances NVDA accessibility support for the LINE desktop application on Windows.
+Provides improved navigation for chat lists, messages, contacts, and message input."""),
+	# version
+	addon_version="1.2.4",
+	# Brief changelog for this version
+	# Translators: what's new content for the add-on version to be shown in the add-on store
+	addon_changelog=_("""See changelog.md for details."""),
+	# Author(s)
+	addon_author="張可揚 <lindsay714322@gmail.com>; 洪鳳恩 <kittyhong0208@gmail.com>",
+	# URL for the add-on documentation support
+	addon_url=None,
+	# URL for the add-on repository where the source code can be found
+	addon_sourceURL=None,
+	# Documentation file name
+	addon_docFileName="readme.html",
+	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
+	addon_minimumNVDAVersion="2022.1",
+	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
+	addon_lastTestedNVDAVersion="2026.1",
+	# Add-on update channel (default is None, denoting stable releases,
+	# and for development releases, use "dev".)
+	# Do not change unless you know what you are doing!
+	addon_updateChannel=None,
+	# Add-on license such as GPL 2
+	addon_license="GPL 2",
+	# URL for the license document the ad-on is licensed under
+	addon_licenseURL=None,
+)
+
+# Define the python files that are the sources of your add-on.
+pythonSources: list[str] = ["addon/appModules/*.py", "addon/globalPlugins/*.py"]
+
+# Files that contain strings for translation. Usually your python sources
+i18nSources: list[str] = pythonSources + ["buildVars.py"]
+
+# Files that will be ignored when building the nvda-addon file
+excludedFiles: list[str] = []
+
+# Base language for the NVDA add-on
+baseLanguage: str = "en"
+
+# Markdown extensions for add-on documentation
+markdownExtensions: list[str] = []
+
+# Custom braille translation tables
+brailleTables: BrailleTables = {}
+
+# Custom speech symbol dictionaries
+symbolDictionaries: SymbolDictionaries = {}

--- a/build_addon.py
+++ b/build_addon.py
@@ -10,7 +10,7 @@ import subprocess
 import markdown
 
 ADDON_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "addon")
-OUTPUT_NAME = "lineDesktop-1.2.3.nvda-addon"
+OUTPUT_NAME = "lineDesktop-1.2.4-beta2.nvda-addon"
 OUTPUT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), OUTPUT_NAME)
 
 # Manifest content matching the format of working NVDA add-ons
@@ -21,7 +21,7 @@ description = \"\"\"Enhances NVDA accessibility support for the LINE desktop app
 Provides improved navigation for chat lists, messages, contacts, and message input.\"\"\"
 author = "張可揚 <lindsay714322@gmail.com>; 洪鳳恩 <kittyhong0208@gmail.com>; 蔡頭<tommytsaitou>"
 url = https://keyang556.github.io/linedesktopnvda/
-version = 1.2.3
+version = 1.2.4-beta2
 changelog = \"\"\"Initial release with LINE desktop accessibility support.\"\"\"
 docFileName = readme.html
 minimumNVDAVersion = 2019.3


### PR DESCRIPTION
## Summary

- Added a dropdown (wx.Choice) in the LINE Desktop settings panel to select the image description model
- Supports 11 Google Generative AI models including Gemini, Gemma, and newer variants  
- Default model: `gemini-3.1-flash-lite-preview`
- User selection is persisted in NVDA's config directory

## Changes

**addon/appModules/line.py**
- Replaced hardcoded `_IMAGE_DESCRIPTION_MODEL` with `_IMAGE_DESCRIPTION_DEFAULT_MODEL`
- Added `_IMAGE_DESCRIPTION_AVAILABLE_MODELS` tuple with all 11 supported models
- Added `getUserImageModel()` / `setUserImageModel()` to persist user choice
- Added `_getEffectiveImageModel()` that returns user choice or default
- Updated `_describeImageBytes()` to use the effective model

**addon/globalPlugins/lineDesktopHelper.py**
- Added dropdown control in `makeSettings()` labeled "圖片描述模型"
- Added `_loadModelOptions()` helper to fetch available models and current selection
- Extended `onSave()` to persist the user's selected model
- Dropdown is positioned below the API key field in the settings panel

## Testing Notes

- Model selection is validated against the allowed list before saving
- Selecting the default model removes the preference file
- Verify that `gemma-3-27b-it` is the correct API model ID (marked as needing confirmation)
- Ensure all 11 model IDs exist in the Google Generative Language API

🤖 Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 在 LINE Desktop NVDA 附加元件的設定面板中新增圖片描述模型下拉選單，讓使用者可從 11 個 Google Generative AI 模型中選擇，並將選擇持久化至 NVDA 設定目錄中的純文字檔案。

主要變更：
- `addon/appModules/line.py`：將硬編碼的 `_IMAGE_DESCRIPTION_MODEL` 替換為可設定的系統，包含 `_IMAGE_DESCRIPTION_AVAILABLE_MODELS` 元組、`getUserImageModel()` / `setUserImageModel()` 磁碟持久化，以及具模組層級快取的 `_getEffectiveImageModel()`。
- `addon/globalPlugins/lineDesktopHelper.py`：在設定面板新增 `wx.Choice` 下拉選單，並在 `onSave()` 中持久化使用者選擇；不過模型儲存的例外處理區塊缺少使用者可見的錯誤對話框，與 API Key 的錯誤處理不一致。
- `buildVars.py`（新增）：scons 構建設定，但版本號（`1.2.4`）與 `build_addon.py` 的 `1.2.4-beta2` 不一致，且最低 NVDA 版本要求相差三年（`2022.1` vs `2019.3`）。

先前審查執行緒中指出的邏輯不一致問題（`onSave` 中基準值不統一）已在本次 PR 中修正。

<h3>Confidence Score: 4/5</h3>

核心功能邏輯正確、快取設計一致，版本號不一致問題需在合併前確認後即可合併。

先前審查執行緒中的邏輯不一致問題已修正；新增的快取機制（_cachedEffectiveImageModel）與既有 API Key 快取設計一致；唯一的 P1 問題是 buildVars.py 與 build_addon.py 的版本號及最低 NVDA 版本要求不一致，需確認後統一。其餘為 P2 樣式建議。

buildVars.py — 版本號（1.2.4 vs 1.2.4-beta2）及最低 NVDA 版本（2022.1 vs 2019.3）需與 build_addon.py 對齊。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增模型選擇的持久化邏輯（getUserImageModel / setUserImageModel / _getEffectiveImageModel），並以模組層級快取取代每次磁碟讀取；先前審查執行緒指出的邏輯不一致問題（onSave 基準值）已修正。 |
| addon/globalPlugins/lineDesktopHelper.py | 在設定面板新增圖片描述模型下拉選單；onSave 中模型儲存失敗的 except 區塊缺少 messageBox，與 API Key 的錯誤處理不一致。 |
| buildVars.py | 新增 scons 構建設定檔，但版本號（1.2.4）與 build_addon.py（1.2.4-beta2）不一致，且最低 NVDA 版本要求（2022.1 vs 2019.3）互相矛盾。 |
| build_addon.py | 版本號從 1.2.3 更新至 1.2.4-beta2，與 buildVars.py 的 1.2.4 版本號不一致。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as 使用者
    participant Panel as LineDesktopSettingsPanel
    participant line as appModules/line.py
    participant Disk as 磁碟 (configPath)

    User->>Panel: 開啟 NVDA 設定面板
    Panel->>line: _loadModelOptions()
    line->>Disk: 讀取 line_desktop_image_model.txt
    Disk-->>line: 模型 ID（或 None）
    line-->>Panel: (choices, defaultModel, currentModel)
    Panel->>Panel: 設定 wx.Choice 選取項目

    User->>Panel: 選擇模型並按儲存
    Panel->>line: setUserImageModel(newModel)
    alt newModel == default 或為空
        line->>Disk: 刪除 line_desktop_image_model.txt
    else newModel 為有效模型
        line->>Disk: 寫入 line_desktop_image_model.txt
    end
    line->>line: 更新 _cachedEffectiveImageModel

    User->>Panel: 觸發圖片描述
    Panel->>line: _describeImageBytes(pngBytes)
    line->>line: _getEffectiveImageModel()
    Note over line: 若快取為 _NOT_COMPUTED 則從磁碟延遲載入
    line->>line: 組裝 API endpoint URL
    line->>line: 呼叫 Google Generative AI API
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AbuildVars.py%3A27-40%0A**%E7%89%88%E6%9C%AC%E8%99%9F%E8%88%87%E6%9C%80%E4%BD%8E%20NVDA%20%E7%89%88%E6%9C%AC%E4%B8%8D%E4%B8%80%E8%87%B4**%0A%0A%60buildVars.py%60%EF%BC%88scons%20%E6%A7%8B%E5%BB%BA%E7%B3%BB%E7%B5%B1%EF%BC%89%E8%88%87%20%60build_addon.py%60%EF%BC%88%E8%87%AA%E8%A8%82%E6%A7%8B%E5%BB%BA%E8%85%B3%E6%9C%AC%EF%BC%89%E4%B9%8B%E9%96%93%E6%9C%89%E5%85%A9%E8%99%95%E4%B8%8D%E4%B8%80%E8%87%B4%EF%BC%9A%0A%0A1.%20**%E7%89%88%E6%9C%AC%E8%99%9F**%EF%BC%9A%60buildVars.py%60%20%E7%82%BA%20%60%221.2.4%22%60%EF%BC%88%E7%A9%A9%E5%AE%9A%E7%89%88%EF%BC%89%EF%BC%8C%E8%80%8C%20%60build_addon.py%60%20%E7%82%BA%20%60%221.2.4-beta2%22%60%EF%BC%88%E6%B8%AC%E8%A9%A6%E7%89%88%EF%BC%89%E3%80%82%E8%8B%A5%20NVDA%20%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E5%95%86%E5%BA%97%E4%BD%BF%E7%94%A8%20%60buildVars.py%60%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E5%B0%87%E7%9C%8B%E5%88%B0%E7%A9%A9%E5%AE%9A%E7%89%88%E7%89%88%E6%9C%AC%E8%99%9F%EF%BC%9B%E8%8B%A5%E4%BD%BF%E7%94%A8%20%60build_addon.py%60%EF%BC%8C%E5%89%87%E9%A1%AF%E7%A4%BA%20beta%E3%80%82%0A%0A2.%20**%E6%9C%80%E4%BD%8E%20NVDA%20%E7%89%88%E6%9C%AC**%EF%BC%9A%60buildVars.py%60%20%E5%AE%A3%E5%91%8A%20%60addon_minimumNVDAVersion%3D%222022.1%22%60%EF%BC%8C%E8%80%8C%20%60build_addon.py%60%20%E7%9A%84%20manifest%20%E6%98%AF%20%60minimumNVDAVersion%20%3D%202019.3%60%E3%80%82%E5%85%A9%E8%80%85%E7%9B%B8%E5%B7%AE%E4%B8%89%E5%B9%B4%EF%BC%8C%E6%9C%83%E5%BD%B1%E9%9F%BF%E5%93%AA%E4%BA%9B%20NVDA%20%E7%89%88%E6%9C%AC%E7%9A%84%E4%BD%BF%E7%94%A8%E8%80%85%E8%83%BD%E5%AE%89%E8%A3%9D%E6%AD%A4%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E7%B5%B1%E4%B8%80%E5%85%A9%E5%80%8B%E6%AA%94%E6%A1%88%E4%B8%AD%E7%9A%84%E7%89%88%E6%9C%AC%E8%B3%87%E8%A8%8A%EF%BC%8C%E4%BB%A5%E9%81%BF%E5%85%8D%E9%83%A8%E7%BD%B2%E6%99%82%E7%94%A2%E7%94%9F%E6%B7%B7%E6%B7%86%E3%80%82%0A%0A%23%23%23%20Issue%202%20of%202%0Aaddon%2FglobalPlugins%2FlineDesktopHelper.py%3A225-229%0A**%E6%A8%A1%E5%9E%8B%E5%84%B2%E5%AD%98%E5%A4%B1%E6%95%97%E6%99%82%E7%BC%BA%E5%B0%91%E4%BD%BF%E7%94%A8%E8%80%85%E6%8F%90%E7%A4%BA**%0A%0A%E6%A8%A1%E5%9E%8B%E5%84%B2%E5%AD%98%E7%9A%84%20%60except%20Exception%60%20%E5%8D%80%E5%A1%8A%EF%BC%88%E7%AC%AC%20225%E2%80%93229%20%E8%A1%8C%EF%BC%89%E5%8F%AA%E8%A8%98%E9%8C%84%20%60log.warning%60%EF%BC%8C%E6%B2%92%E6%9C%89%E9%A1%AF%E7%A4%BA%20%60messageBox%60%E3%80%82%E7%9B%B8%E6%AF%94%E4%B9%8B%E4%B8%8B%EF%BC%8CAPI%20Key%20%E5%84%B2%E5%AD%98%E7%9A%84%E5%90%8C%E7%AD%89%E4%BE%8B%E5%A4%96%E8%99%95%E7%90%86%E5%8D%80%E5%A1%8A%EF%BC%88%E7%AC%AC%20191%E2%80%93202%20%E8%A1%8C%EF%BC%89%E6%9C%83%E5%90%91%E4%BD%BF%E7%94%A8%E8%80%85%E9%A1%AF%E7%A4%BA%E9%8C%AF%E8%AA%A4%E5%B0%8D%E8%A9%B1%E6%A1%86%EF%BC%9A%0A%0A%60%60%60python%0Agui.messageBox%28%0A%20%20%20%20_%28%22%E7%84%A1%E6%B3%95%E8%BC%89%E5%85%A5%20API%20Key%20%E8%A8%AD%E5%AE%9A%EF%BC%8C%E8%AB%8B%E7%A2%BA%E8%AA%8D%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E5%AE%8C%E6%95%B4%E6%80%A7%E3%80%82%22%29%2C%0A%20%20%20%20_%28%22LINE%20Desktop%20-%20%E8%A8%AD%E5%AE%9A%E9%8C%AF%E8%AA%A4%22%29%2C%0A%20%20%20%20wx.OK%20%7C%20wx.ICON_ERROR%2C%0A%20%20%20%20self%2C%0A%29%0A%60%60%60%0A%0A%E8%8B%A5%20%60appModules.line%60%20%E6%A8%A1%E7%B5%84%E8%BC%89%E5%85%A5%E5%A4%B1%E6%95%97%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E6%8C%89%E4%B8%8B%E3%80%8C%E5%84%B2%E5%AD%98%E3%80%8D%E5%BE%8C%E4%B8%8D%E6%9C%83%E6%94%B6%E5%88%B0%E4%BB%BB%E4%BD%95%E5%8F%8D%E9%A5%8B%EF%BC%8C%E8%AA%A4%E4%BB%A5%E7%82%BA%E6%A8%A1%E5%9E%8B%E9%81%B8%E6%93%87%E5%B7%B2%E5%84%B2%E5%AD%98%E6%88%90%E5%8A%9F%E3%80%82%E5%BB%BA%E8%AD%B0%E5%9C%A8%E6%AD%A4%E8%99%95%E8%A3%9C%E4%B8%8A%E5%B0%8D%E6%87%89%E7%9A%84%20%60messageBox%60%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda&pr=60&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Fawesome-lewin-e0399f%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fawesome-lewin-e0399f%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AbuildVars.py%3A27-40%0A**%E7%89%88%E6%9C%AC%E8%99%9F%E8%88%87%E6%9C%80%E4%BD%8E%20NVDA%20%E7%89%88%E6%9C%AC%E4%B8%8D%E4%B8%80%E8%87%B4**%0A%0A%60buildVars.py%60%EF%BC%88scons%20%E6%A7%8B%E5%BB%BA%E7%B3%BB%E7%B5%B1%EF%BC%89%E8%88%87%20%60build_addon.py%60%EF%BC%88%E8%87%AA%E8%A8%82%E6%A7%8B%E5%BB%BA%E8%85%B3%E6%9C%AC%EF%BC%89%E4%B9%8B%E9%96%93%E6%9C%89%E5%85%A9%E8%99%95%E4%B8%8D%E4%B8%80%E8%87%B4%EF%BC%9A%0A%0A1.%20**%E7%89%88%E6%9C%AC%E8%99%9F**%EF%BC%9A%60buildVars.py%60%20%E7%82%BA%20%60%221.2.4%22%60%EF%BC%88%E7%A9%A9%E5%AE%9A%E7%89%88%EF%BC%89%EF%BC%8C%E8%80%8C%20%60build_addon.py%60%20%E7%82%BA%20%60%221.2.4-beta2%22%60%EF%BC%88%E6%B8%AC%E8%A9%A6%E7%89%88%EF%BC%89%E3%80%82%E8%8B%A5%20NVDA%20%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E5%95%86%E5%BA%97%E4%BD%BF%E7%94%A8%20%60buildVars.py%60%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E5%B0%87%E7%9C%8B%E5%88%B0%E7%A9%A9%E5%AE%9A%E7%89%88%E7%89%88%E6%9C%AC%E8%99%9F%EF%BC%9B%E8%8B%A5%E4%BD%BF%E7%94%A8%20%60build_addon.py%60%EF%BC%8C%E5%89%87%E9%A1%AF%E7%A4%BA%20beta%E3%80%82%0A%0A2.%20**%E6%9C%80%E4%BD%8E%20NVDA%20%E7%89%88%E6%9C%AC**%EF%BC%9A%60buildVars.py%60%20%E5%AE%A3%E5%91%8A%20%60addon_minimumNVDAVersion%3D%222022.1%22%60%EF%BC%8C%E8%80%8C%20%60build_addon.py%60%20%E7%9A%84%20manifest%20%E6%98%AF%20%60minimumNVDAVersion%20%3D%202019.3%60%E3%80%82%E5%85%A9%E8%80%85%E7%9B%B8%E5%B7%AE%E4%B8%89%E5%B9%B4%EF%BC%8C%E6%9C%83%E5%BD%B1%E9%9F%BF%E5%93%AA%E4%BA%9B%20NVDA%20%E7%89%88%E6%9C%AC%E7%9A%84%E4%BD%BF%E7%94%A8%E8%80%85%E8%83%BD%E5%AE%89%E8%A3%9D%E6%AD%A4%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E3%80%82%0A%0A%E5%BB%BA%E8%AD%B0%E7%B5%B1%E4%B8%80%E5%85%A9%E5%80%8B%E6%AA%94%E6%A1%88%E4%B8%AD%E7%9A%84%E7%89%88%E6%9C%AC%E8%B3%87%E8%A8%8A%EF%BC%8C%E4%BB%A5%E9%81%BF%E5%85%8D%E9%83%A8%E7%BD%B2%E6%99%82%E7%94%A2%E7%94%9F%E6%B7%B7%E6%B7%86%E3%80%82%0A%0A%23%23%23%20Issue%202%20of%202%0Aaddon%2FglobalPlugins%2FlineDesktopHelper.py%3A225-229%0A**%E6%A8%A1%E5%9E%8B%E5%84%B2%E5%AD%98%E5%A4%B1%E6%95%97%E6%99%82%E7%BC%BA%E5%B0%91%E4%BD%BF%E7%94%A8%E8%80%85%E6%8F%90%E7%A4%BA**%0A%0A%E6%A8%A1%E5%9E%8B%E5%84%B2%E5%AD%98%E7%9A%84%20%60except%20Exception%60%20%E5%8D%80%E5%A1%8A%EF%BC%88%E7%AC%AC%20225%E2%80%93229%20%E8%A1%8C%EF%BC%89%E5%8F%AA%E8%A8%98%E9%8C%84%20%60log.warning%60%EF%BC%8C%E6%B2%92%E6%9C%89%E9%A1%AF%E7%A4%BA%20%60messageBox%60%E3%80%82%E7%9B%B8%E6%AF%94%E4%B9%8B%E4%B8%8B%EF%BC%8CAPI%20Key%20%E5%84%B2%E5%AD%98%E7%9A%84%E5%90%8C%E7%AD%89%E4%BE%8B%E5%A4%96%E8%99%95%E7%90%86%E5%8D%80%E5%A1%8A%EF%BC%88%E7%AC%AC%20191%E2%80%93202%20%E8%A1%8C%EF%BC%89%E6%9C%83%E5%90%91%E4%BD%BF%E7%94%A8%E8%80%85%E9%A1%AF%E7%A4%BA%E9%8C%AF%E8%AA%A4%E5%B0%8D%E8%A9%B1%E6%A1%86%EF%BC%9A%0A%0A%60%60%60python%0Agui.messageBox%28%0A%20%20%20%20_%28%22%E7%84%A1%E6%B3%95%E8%BC%89%E5%85%A5%20API%20Key%20%E8%A8%AD%E5%AE%9A%EF%BC%8C%E8%AB%8B%E7%A2%BA%E8%AA%8D%E9%99%84%E5%8A%A0%E5%85%83%E4%BB%B6%E5%AE%8C%E6%95%B4%E6%80%A7%E3%80%82%22%29%2C%0A%20%20%20%20_%28%22LINE%20Desktop%20-%20%E8%A8%AD%E5%AE%9A%E9%8C%AF%E8%AA%A4%22%29%2C%0A%20%20%20%20wx.OK%20%7C%20wx.ICON_ERROR%2C%0A%20%20%20%20self%2C%0A%29%0A%60%60%60%0A%0A%E8%8B%A5%20%60appModules.line%60%20%E6%A8%A1%E7%B5%84%E8%BC%89%E5%85%A5%E5%A4%B1%E6%95%97%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E6%8C%89%E4%B8%8B%E3%80%8C%E5%84%B2%E5%AD%98%E3%80%8D%E5%BE%8C%E4%B8%8D%E6%9C%83%E6%94%B6%E5%88%B0%E4%BB%BB%E4%BD%95%E5%8F%8D%E9%A5%8B%EF%BC%8C%E8%AA%A4%E4%BB%A5%E7%82%BA%E6%A8%A1%E5%9E%8B%E9%81%B8%E6%93%87%E5%B7%B2%E5%84%B2%E5%AD%98%E6%88%90%E5%8A%9F%E3%80%82%E5%BB%BA%E8%AD%B0%E5%9C%A8%E6%AD%A4%E8%99%95%E8%A3%9C%E4%B8%8A%E5%B0%8D%E6%87%89%E7%9A%84%20%60messageBox%60%E3%80%82%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: buildVars.py
Line: 27-40

Comment:
**版本號與最低 NVDA 版本不一致**

`buildVars.py`（scons 構建系統）與 `build_addon.py`（自訂構建腳本）之間有兩處不一致：

1. **版本號**：`buildVars.py` 為 `"1.2.4"`（穩定版），而 `build_addon.py` 為 `"1.2.4-beta2"`（測試版）。若 NVDA 附加元件商店使用 `buildVars.py`，使用者將看到穩定版版本號；若使用 `build_addon.py`，則顯示 beta。

2. **最低 NVDA 版本**：`buildVars.py` 宣告 `addon_minimumNVDAVersion="2022.1"`，而 `build_addon.py` 的 manifest 是 `minimumNVDAVersion = 2019.3`。兩者相差三年，會影響哪些 NVDA 版本的使用者能安裝此附加元件。

建議統一兩個檔案中的版本資訊，以避免部署時產生混淆。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: addon/globalPlugins/lineDesktopHelper.py
Line: 225-229

Comment:
**模型儲存失敗時缺少使用者提示**

模型儲存的 `except Exception` 區塊（第 225–229 行）只記錄 `log.warning`，沒有顯示 `messageBox`。相比之下，API Key 儲存的同等例外處理區塊（第 191–202 行）會向使用者顯示錯誤對話框：

```python
gui.messageBox(
    _("無法載入 API Key 設定，請確認附加元件完整性。"),
    _("LINE Desktop - 設定錯誤"),
    wx.OK | wx.ICON_ERROR,
    self,
)
```

若 `appModules.line` 模組載入失敗，使用者按下「儲存」後不會收到任何反饋，誤以為模型選擇已儲存成功。建議在此處補上對應的 `messageBox`。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Address review: fix model cache, change-..."](https://github.com/keyang556/linedesktopnvda/commit/63264bca253ddb4de5485775360f45721829cdb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29067092)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->