### PR TITLE
Add customizable image description prompt setting

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1697,6 +1697,7 @@ _IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB = (
 )
 _IMAGE_DESCRIPTION_USER_KEY_FILENAME = "line_desktop_image_api_key.dat"
 _IMAGE_DESCRIPTION_USER_MODEL_FILENAME = "line_desktop_image_model.txt"
+_IMAGE_DESCRIPTION_USER_PROMPT_FILENAME = "line_desktop_image_prompt.txt"
 # Default model used when the user has not picked one in the settings panel.
 _IMAGE_DESCRIPTION_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
 # Models exposed in the settings panel dropdown. The order here is the order
@@ -1723,7 +1724,10 @@ _IMAGE_DESCRIPTION_AVAILABLE_MODELS = (
 _IMAGE_DESCRIPTION_ENDPOINT = (
 	"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
 )
-_IMAGE_DESCRIPTION_PROMPT = "請用繁體中文簡要描述這張圖片的內容。"
+_IMAGE_DESCRIPTION_DEFAULT_PROMPT = "請用繁體中文簡要描述這張圖片的內容。"
+# Maximum length accepted from user-supplied prompts, to avoid pathological
+# payloads being sent to the API.
+_IMAGE_DESCRIPTION_PROMPT_MAX_LEN = 2000
 
 _IMAGE_API_KEY_SALT_LEN = 16
 _IMAGE_API_KEY_MAC_LEN = 16
@@ -1930,6 +1934,71 @@ def _getEffectiveImageModel():
 	return _cachedEffectiveImageModel
 
 
+def _getImagePromptStorePath():
+	"""Return the filesystem path for the user-supplied description prompt."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_PROMPT_FILENAME)
+
+
+def getUserImagePrompt():
+	"""Return the prompt previously set by the user, or None."""
+	path = _getImagePromptStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			value = f.read()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user image prompt: {e}", exc_info=True)
+		return None
+	value = value.strip()
+	if not value:
+		return None
+	return value
+
+
+_cachedEffectiveImagePrompt = _NOT_COMPUTED
+
+
+def setUserImagePrompt(text):
+	"""Persist a user-supplied prompt. Empty/None or the default clears the file."""
+	global _cachedEffectiveImagePrompt
+	path = _getImagePromptStorePath()
+	if not path:
+		return False
+	try:
+		cleaned = (text or "").strip()
+		if cleaned:
+			cleaned = cleaned[:_IMAGE_DESCRIPTION_PROMPT_MAX_LEN]
+		if not cleaned or cleaned == _IMAGE_DESCRIPTION_DEFAULT_PROMPT:
+			if os.path.isfile(path):
+				os.remove(path)
+			_cachedEffectiveImagePrompt = _IMAGE_DESCRIPTION_DEFAULT_PROMPT
+			return True
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(cleaned)
+		_cachedEffectiveImagePrompt = cleaned
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user image prompt: {e}", exc_info=True)
+		return False
+
+
+def _getEffectiveImagePrompt():
+	"""Return the cached prompt; lazily resolved from disk on first call."""
+	global _cachedEffectiveImagePrompt
+	if _cachedEffectiveImagePrompt is _NOT_COMPUTED:
+		_cachedEffectiveImagePrompt = getUserImagePrompt() or _IMAGE_DESCRIPTION_DEFAULT_PROMPT
+	return _cachedEffectiveImagePrompt
+
+
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")
 _NOTES_OCR_KEYWORDS = (
 	"記事本",
@@ -2059,7 +2128,7 @@ def _describeImageBytes(pngBytes, timeout=30.0):
 			"contents": [
 				{
 					"parts": [
-						{"text": _IMAGE_DESCRIPTION_PROMPT},
+						{"text": _getEffectiveImagePrompt()},
 						{
 							"inline_data": {
 								"mime_type": "image/png",

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -131,6 +131,17 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		if self._modelChoices:
 			self._modelChoice.SetSelection(selectIndex)
 
+		# Translators: Text field label for the image-description prompt
+		promptLabel = _("圖片描述提示詞，留空則使用預設 (&P)")
+		self._promptText = sHelper.addLabeledControl(
+			promptLabel,
+			wx.TextCtrl,
+			style=wx.TE_MULTILINE,
+			size=(-1, 80),
+		)
+		self._promptDefault, currentPrompt = self._loadPromptOptions()
+		self._promptText.SetValue(currentPrompt)
+
 	def _loadCurrentApiKey(self):
 		try:
 			from appModules.line import getUserImageApiKey
@@ -158,6 +169,20 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		except Exception:
 			log.debug("LINE: cannot load image model options", exc_info=True)
 			return ((), "", "")
+
+	def _loadPromptOptions(self):
+		"""Return (default_prompt, currently_configured_prompt)."""
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_DEFAULT_PROMPT,
+				getUserImagePrompt,
+			)
+
+			current = getUserImagePrompt() or _IMAGE_DESCRIPTION_DEFAULT_PROMPT
+			return (_IMAGE_DESCRIPTION_DEFAULT_PROMPT, current)
+		except Exception:
+			log.debug("LINE: cannot load image prompt options", exc_info=True)
+			return ("", "")
 
 	def onSave(self):
 		# Qt accessibility env var
@@ -225,6 +250,31 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		except Exception:
 			log.warning(
 				"LINE: cannot load image model helpers from settings panel",
+				exc_info=True,
+			)
+
+		# Image description prompt
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_DEFAULT_PROMPT,
+				getUserImagePrompt,
+				setUserImagePrompt,
+			)
+
+			newPrompt = self._promptText.GetValue().strip()
+			currentPrompt = getUserImagePrompt() or _IMAGE_DESCRIPTION_DEFAULT_PROMPT
+			if newPrompt != currentPrompt:
+				if not setUserImagePrompt(newPrompt):
+					gui.messageBox(
+						# Translators: Error shown when saving the image prompt fails
+						_("儲存圖片描述提示詞失敗，請重試。"),
+						_("LINE Desktop - 設定錯誤"),
+						wx.OK | wx.ICON_ERROR,
+						self,
+					)
+		except Exception:
+			log.warning(
+				"LINE: cannot load image prompt helpers from settings panel",
 				exc_info=True,
 			)
 

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -139,8 +139,7 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			style=wx.TE_MULTILINE,
 			size=(-1, 80),
 		)
-		self._promptDefault, currentPrompt = self._loadPromptOptions()
-		self._promptText.SetValue(currentPrompt)
+		self._promptText.SetValue(self._loadCurrentPrompt())
 
 	def _loadCurrentApiKey(self):
 		try:
@@ -170,19 +169,17 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			log.debug("LINE: cannot load image model options", exc_info=True)
 			return ((), "", "")
 
-	def _loadPromptOptions(self):
-		"""Return (default_prompt, currently_configured_prompt)."""
+	def _loadCurrentPrompt(self):
 		try:
 			from appModules.line import (
 				_IMAGE_DESCRIPTION_DEFAULT_PROMPT,
 				getUserImagePrompt,
 			)
 
-			current = getUserImagePrompt() or _IMAGE_DESCRIPTION_DEFAULT_PROMPT
-			return (_IMAGE_DESCRIPTION_DEFAULT_PROMPT, current)
+			return getUserImagePrompt() or _IMAGE_DESCRIPTION_DEFAULT_PROMPT
 		except Exception:
-			log.debug("LINE: cannot load image prompt options", exc_info=True)
-			return ("", "")
+			log.debug("LINE: cannot load image prompt for settings panel", exc_info=True)
+			return ""
 
 	def onSave(self):
 		# Qt accessibility env var

--- a/buildVars.py
+++ b/buildVars.py
@@ -24,7 +24,7 @@ addon_info = AddonInfo(
 	addon_description=_("""Enhances NVDA accessibility support for the LINE desktop application on Windows.
 Provides improved navigation for chat lists, messages, contacts, and message input."""),
 	# version
-	addon_version="1.2.4",
+	addon_version="1.2.4-beta3",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
 	addon_changelog=_("""See changelog.md for details."""),
@@ -37,7 +37,7 @@ Provides improved navigation for chat lists, messages, contacts, and message inp
 	# Documentation file name
 	addon_docFileName="readme.html",
 	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
-	addon_minimumNVDAVersion="2022.1",
+	addon_minimumNVDAVersion="2019.3",
 	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
 	addon_lastTestedNVDAVersion="2026.1",
 	# Add-on update channel (default is None, denoting stable releases,

--- a/build_addon.py
+++ b/build_addon.py
@@ -10,7 +10,7 @@ import subprocess
 import markdown
 
 ADDON_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "addon")
-OUTPUT_NAME = "lineDesktop-1.2.4-beta2.nvda-addon"
+OUTPUT_NAME = "lineDesktop-1.2.4-beta3.nvda-addon"
 OUTPUT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), OUTPUT_NAME)
 
 # Manifest content matching the format of working NVDA add-ons
@@ -21,7 +21,7 @@ description = \"\"\"Enhances NVDA accessibility support for the LINE desktop app
 Provides improved navigation for chat lists, messages, contacts, and message input.\"\"\"
 author = "張可揚 <lindsay714322@gmail.com>; 洪鳳恩 <kittyhong0208@gmail.com>; 蔡頭<tommytsaitou>"
 url = https://keyang556.github.io/linedesktopnvda/
-version = 1.2.4-beta2
+version = 1.2.4-beta3
 changelog = \"\"\"Initial release with LINE desktop accessibility support.\"\"\"
 docFileName = readme.html
 minimumNVDAVersion = 2019.3

--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,3 @@
 Use this file to explain what has changed in your add-on since the previous release. This will be included automatically in the release description when used with GitHub actions.
+
+- 在「LINE Desktop」設定面板新增「圖片描述提示詞」欄位，可自訂傳送給圖片描述模型的提示詞；留空則使用預設值。


### PR DESCRIPTION
## Summary
- New multi-line text field under **NVDA Preferences → Settings → LINE Desktop**: `圖片描述提示詞，留空則使用預設 (&P)`, letting users override the prompt sent to the image-description model.
- Adds `getUserImagePrompt` / `setUserImagePrompt` / `_getEffectiveImagePrompt` in `addon/appModules/line.py`, with on-disk persistence (`line_desktop_image_prompt.txt` under NVDA's user config) and an in-memory cache, mirroring the existing API-key / model pattern.
- Gemini request now uses `_getEffectiveImagePrompt()` instead of the hardcoded constant; empty input or a value equal to the default clears the override file so users transparently fall back to the built-in prompt `請用繁體中文簡要描述這張圖片的內容。`.

## Notes for reviewers
- Renamed the internal constant `_IMAGE_DESCRIPTION_PROMPT` → `_IMAGE_DESCRIPTION_DEFAULT_PROMPT`; grep confirms no other references remained.
- Persisted values are trimmed and capped at 2000 chars (`_IMAGE_DESCRIPTION_PROMPT_MAX_LEN`) to avoid pathological payloads being sent to the API.
- No plaintext secrets touched — only the prompt file is new; API-key obfuscation paths are unchanged.
- Changelog entry added.

## Test plan
- [x] Install the addon in NVDA, open Preferences → Settings → LINE Desktop, verify the prompt field renders with the current (default) value pre-filled.
- [ ] Edit the prompt, save, re-open settings → value persists.
- [ ] Clear the field, save → `line_desktop_image_prompt.txt` is removed and next image description uses the default prompt.
- [ ] Trigger an image description in LINE and confirm the request uses the configured prompt (check NVDA log at debug level if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 在「LINE Desktop」設定面板新增一個多行文字欄位，讓使用者可自訂傳送給 Gemini 圖片描述模型的提示詞；空白或等同預設值時會清除覆寫檔案，透明地回退到內建提示詞 `請用繁體中文簡要描述這張圖片的內容。`。

主要變更摘要：
- 在 `line.py` 新增 `getUserImagePrompt` / `setUserImagePrompt` / `_getEffectiveImagePrompt`，儲存於 `line_desktop_image_prompt.txt`，並加入 2000 字元上限保護，完整鏡像既有的 API key / 模型選擇模式。
- 在 `lineDesktopHelper.py` 新增 `wx.TextCtrl`（多行）及對應的 `_loadCurrentPrompt()` 與 `onSave` 邏輯，且正確**未儲存** `self._promptDefault` 無用欄位（改善了前次審閱提及的既有問題）。
- 版本號提升至 `1.2.4-beta3`；`addon_minimumNVDAVersion` 從 `2022.1` 降至 `2019.3`（此點已在前次審閱中標示，本次未處理）。
- Changelog 更新正確。

<h3>Confidence Score: 4/5</h3>

實作邏輯正確且完整，可合併；minimumNVDAVersion 降版問題為前次審閱遺留項目，確認相容性後即可。

提示詞的儲存、快取、截斷、預設回退邏輯均正確，且正確避免了前次審閱指出的無用 _promptDefault 欄位。唯一遺留問題為 minimumNVDAVersion 從 2022.1 降至 2019.3（已在前次審閱中標示），確認舊版 NVDA 相容性後即可升至 5/5。

buildVars.py — minimumNVDAVersion 降版（前次審閱遺留，確認相容性即可）

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 getUserImagePrompt / setUserImagePrompt / _getEffectiveImagePrompt，完整鏡像既有模型選擇模式；邏輯正確，快取更新、截斷保護、預設值回退均無誤。 |
| addon/globalPlugins/lineDesktopHelper.py | 新增多行提示詞文字欄位、載入/儲存邏輯；正確未加入無用的 self._promptDefault；onSave 錯誤處理與既有 model 區塊一致。 |
| buildVars.py | 版本升至 1.2.4-beta3；minimumNVDAVersion 從 2022.1 降至 2019.3（前次審閱已標示，尚未處理）。 |
| build_addon.py | 輸出檔名與版本號同步更新至 beta3，無其他邏輯變動。 |
| changelog.md | 新增本次功能的更新說明，內容清楚正確。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as 使用者
    participant Panel as LineDesktopSettingsPanel
    participant line as line.py
    participant Disk as 磁碟 (configPath)
    participant Gemini as Gemini API

    User->>Panel: 開啟設定面板
    Panel->>line: getUserImagePrompt()
    line->>Disk: 讀取 line_desktop_image_prompt.txt
    Disk-->>line: 自訂提示詞 或 None
    line-->>Panel: 提示詞（或預設值）
    Panel-->>User: 顯示多行文字欄位（預填）

    User->>Panel: 修改提示詞並儲存
    Panel->>line: setUserImagePrompt(newPrompt)
    alt 空白 或 等於預設值
        line->>Disk: 刪除 line_desktop_image_prompt.txt
        line->>line: _cachedEffectiveImagePrompt = 預設值
    else 有效自訂提示詞
        line->>Disk: 寫入 line_desktop_image_prompt.txt（截斷至 2000 字元）
        line->>line: _cachedEffectiveImagePrompt = 自訂值
    end

    User->>line: 觸發圖片描述
    line->>line: _getEffectiveImagePrompt()（從快取取得）
    line->>Gemini: POST /generateContent（含提示詞 + 圖片）
    Gemini-->>line: 描述文字
    line-->>User: 朗讀描述
```

<sub>Reviews (2): Last reviewed commit: ["Remove unused \_promptDefault; align with..."](https://github.com/keyang556/linedesktopnvda/commit/1876a073987d4f1a3a736428841e2d11f006d4fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29380880)</sub>

<!-- /greptile_comment -->