### PR TITLE
Add image description dialog with follow-up questions

### DIFF
--- a/addon/appModules/_imageDescriptionDialog.py
+++ b/addon/appModules/_imageDescriptionDialog.py
@@ -6,13 +6,7 @@ from logHandler import log
 
 
 class ImageDescriptionDialog(wx.Dialog):
-	"""Dialog showing an image description transcript and follow-up questions.
-
-	The transcript is rendered in a read-only multiline text control so that
-	NVDA can navigate the text line-by-line (cursor keys, word/char review).
-	Users can type follow-up questions; the Gemini multi-turn conversation
-	history (including the original image) is preserved across replies.
-	"""
+	"""Image description dialog with a read-only transcript and multi-turn follow-up input."""
 
 	def __init__(self, apiCaller, initialContents, initialUserPrompt, initialDescription):
 		super().__init__(
@@ -31,8 +25,7 @@ class ImageDescriptionDialog(wx.Dialog):
 		panel = wx.Panel(self)
 		sizer = wx.BoxSizer(wx.VERTICAL)
 
-		# Translators: Label above the read-only transcript in the image
-		# description dialog.
+		# Translators: Label above the conversation transcript.
 		transcriptLabel = wx.StaticText(panel, label=_("對話內容(&T)："))
 		sizer.Add(transcriptLabel, 0, wx.LEFT | wx.RIGHT | wx.TOP, 5)
 
@@ -43,7 +36,6 @@ class ImageDescriptionDialog(wx.Dialog):
 		)
 		sizer.Add(self._transcriptCtrl, 1, wx.EXPAND | wx.ALL, 5)
 
-		# Translators: Status line shown while waiting for a follow-up reply.
 		self._statusLabel = wx.StaticText(panel, label="")
 		sizer.Add(self._statusLabel, 0, wx.LEFT | wx.RIGHT, 5)
 
@@ -84,10 +76,7 @@ class ImageDescriptionDialog(wx.Dialog):
 		self.Bind(wx.EVT_CHAR_HOOK, self._onCharHook)
 
 		self.SetEscapeId(wx.ID_CLOSE)
-		# Put focus on the transcript so the user can cursor-navigate it,
-		# and explicitly speak the initial description once the dialog has
-		# been shown (otherwise NVDA's focus-change announcement interrupts
-		# the speech and only the opening words are heard).
+		# wx.CallAfter defers speech until after Show() so NVDA's focus announcement doesn't cut it off.
 		self._transcriptCtrl.SetInsertionPoint(0)
 		self._transcriptCtrl.SetFocus()
 		wx.CallAfter(self._speak, initialDescription)
@@ -173,9 +162,6 @@ class ImageDescriptionDialog(wx.Dialog):
 			)
 			# Translators: Transcript label for the model's follow-up reply.
 			self._appendTurn(_("回答"), answer)
-			# Put focus on the transcript so the user can cursor-navigate the
-			# new reply, and speak it explicitly since a focus change alone
-			# only reads the cursor line.
 			self._transcriptCtrl.SetInsertionPoint(
 				self._transcriptCtrl.GetLastPosition(),
 			)

--- a/addon/appModules/_imageDescriptionDialog.py
+++ b/addon/appModules/_imageDescriptionDialog.py
@@ -21,6 +21,7 @@ class ImageDescriptionDialog(wx.Dialog):
 		)
 		self._transcript = ""
 		self._pending = False
+		self._closed = False
 
 		panel = wx.Panel(self)
 		sizer = wx.BoxSizer(wx.VERTICAL)
@@ -149,6 +150,8 @@ class ImageDescriptionDialog(wx.Dialog):
 		threading.Thread(target=worker, daemon=True).start()
 
 	def _onApiResult(self, question, answer, err):
+		if self._closed:
+			return
 		self._pending = False
 		self._sendBtn.Enable()
 		self._inputCtrl.Enable()
@@ -176,6 +179,7 @@ class ImageDescriptionDialog(wx.Dialog):
 
 	def _onClose(self, evt):
 		global _dlg
+		self._closed = True  # prevent in-flight wx.CallAfter callbacks from touching destroyed widgets
 		_dlg = None
 		self.Destroy()
 

--- a/addon/appModules/_imageDescriptionDialog.py
+++ b/addon/appModules/_imageDescriptionDialog.py
@@ -1,0 +1,221 @@
+import threading
+
+import wx
+import gui
+from logHandler import log
+
+
+class ImageDescriptionDialog(wx.Dialog):
+	"""Dialog showing an image description transcript and follow-up questions.
+
+	The transcript is rendered in a read-only multiline text control so that
+	NVDA can navigate the text line-by-line (cursor keys, word/char review).
+	Users can type follow-up questions; the Gemini multi-turn conversation
+	history (including the original image) is preserved across replies.
+	"""
+
+	def __init__(self, apiCaller, initialContents, initialUserPrompt, initialDescription):
+		super().__init__(
+			gui.mainFrame,
+			title=_("圖片描述"),
+			style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+		)
+		self._apiCaller = apiCaller
+		self._contents = list(initialContents)
+		self._contents.append(
+			{"role": "model", "parts": [{"text": initialDescription}]},
+		)
+		self._transcript = ""
+		self._pending = False
+
+		panel = wx.Panel(self)
+		sizer = wx.BoxSizer(wx.VERTICAL)
+
+		# Translators: Label above the read-only transcript in the image
+		# description dialog.
+		transcriptLabel = wx.StaticText(panel, label=_("對話內容(&T)："))
+		sizer.Add(transcriptLabel, 0, wx.LEFT | wx.RIGHT | wx.TOP, 5)
+
+		self._transcriptCtrl = wx.TextCtrl(
+			panel,
+			style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_RICH2,
+			size=(600, 300),
+		)
+		sizer.Add(self._transcriptCtrl, 1, wx.EXPAND | wx.ALL, 5)
+
+		# Translators: Status line shown while waiting for a follow-up reply.
+		self._statusLabel = wx.StaticText(panel, label="")
+		sizer.Add(self._statusLabel, 0, wx.LEFT | wx.RIGHT, 5)
+
+		# Translators: Label above the follow-up question input box.
+		inputLabel = wx.StaticText(
+			panel,
+			label=_("後續提問(&Q)（按 Ctrl+Enter 送出）："),
+		)
+		sizer.Add(inputLabel, 0, wx.LEFT | wx.RIGHT | wx.TOP, 5)
+
+		self._inputCtrl = wx.TextCtrl(
+			panel,
+			style=wx.TE_MULTILINE,
+			size=(600, 80),
+		)
+		sizer.Add(self._inputCtrl, 0, wx.EXPAND | wx.ALL, 5)
+
+		btnRow = wx.BoxSizer(wx.HORIZONTAL)
+		# Translators: Button that sends the follow-up question.
+		self._sendBtn = wx.Button(panel, label=_("送出(&S)"))
+		# Translators: Button that closes the image description dialog.
+		closeBtn = wx.Button(panel, wx.ID_CLOSE, _("關閉(&C)"))
+		btnRow.Add(self._sendBtn, 0, wx.RIGHT, 10)
+		btnRow.Add(closeBtn, 0)
+		sizer.Add(btnRow, 0, wx.ALIGN_CENTER | wx.ALL, 5)
+
+		panel.SetSizer(sizer)
+		sizer.Fit(self)
+
+		# Translators: Transcript label for the original prompt turn.
+		self._appendTurn(_("提示"), initialUserPrompt)
+		# Translators: Transcript label for the model's initial description.
+		self._appendTurn(_("描述"), initialDescription)
+
+		self._sendBtn.Bind(wx.EVT_BUTTON, self._onSend)
+		closeBtn.Bind(wx.EVT_BUTTON, self._onClose)
+		self.Bind(wx.EVT_CLOSE, self._onClose)
+		self.Bind(wx.EVT_CHAR_HOOK, self._onCharHook)
+
+		self.SetEscapeId(wx.ID_CLOSE)
+		# Put focus on the transcript so the user can cursor-navigate it,
+		# and explicitly speak the initial description once the dialog has
+		# been shown (otherwise NVDA's focus-change announcement interrupts
+		# the speech and only the opening words are heard).
+		self._transcriptCtrl.SetInsertionPoint(0)
+		self._transcriptCtrl.SetFocus()
+		wx.CallAfter(self._speak, initialDescription)
+
+	def _appendTurn(self, speaker, text):
+		if self._transcript:
+			self._transcript += "\n\n"
+		self._transcript += f"【{speaker}】\n{text}"
+		self._transcriptCtrl.SetValue(self._transcript)
+		self._transcriptCtrl.ShowPosition(self._transcriptCtrl.GetLastPosition())
+
+	def _speak(self, text):
+		"""Speak ``text`` via NVDA, cancelling any prior speech."""
+		if not text:
+			return
+		try:
+			import speech
+
+			speech.cancelSpeech()
+			speech.speakMessage(text)
+		except Exception:
+			log.debug("LINE: image description dialog speech failed", exc_info=True)
+
+	def _onCharHook(self, evt):
+		keyCode = evt.GetKeyCode()
+		if keyCode == wx.WXK_ESCAPE:
+			self.Close()
+			return
+		if (
+			keyCode in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER)
+			and evt.ControlDown()
+			and self.FindFocus() is self._inputCtrl
+		):
+			self._onSend(evt)
+			return
+		evt.Skip()
+
+	def _onSend(self, evt):
+		if self._pending:
+			return
+		question = self._inputCtrl.GetValue().strip()
+		if not question:
+			return
+		self._inputCtrl.SetValue("")
+		# Translators: Transcript label for the user's follow-up question.
+		self._appendTurn(_("提問"), question)
+
+		followup = list(self._contents)
+		followup.append({"role": "user", "parts": [{"text": question}]})
+
+		self._pending = True
+		self._sendBtn.Disable()
+		self._inputCtrl.Disable()
+		# Translators: Status text shown while waiting for the follow-up reply.
+		waitMsg = _("回答中，請稍候…")
+		self._statusLabel.SetLabel(waitMsg)
+		self._speak(waitMsg)
+
+		def worker():
+			try:
+				answer, err = self._apiCaller(followup)
+			except Exception as e:
+				log.warning(
+					f"LINE: image description follow-up failed: {e}",
+					exc_info=True,
+				)
+				answer, err = None, _("圖片描述失敗")
+			wx.CallAfter(self._onApiResult, question, answer, err)
+
+		threading.Thread(target=worker, daemon=True).start()
+
+	def _onApiResult(self, question, answer, err):
+		self._pending = False
+		self._sendBtn.Enable()
+		self._inputCtrl.Enable()
+		self._statusLabel.SetLabel("")
+		if answer:
+			self._contents.append(
+				{"role": "user", "parts": [{"text": question}]},
+			)
+			self._contents.append(
+				{"role": "model", "parts": [{"text": answer}]},
+			)
+			# Translators: Transcript label for the model's follow-up reply.
+			self._appendTurn(_("回答"), answer)
+			# Put focus on the transcript so the user can cursor-navigate the
+			# new reply, and speak it explicitly since a focus change alone
+			# only reads the cursor line.
+			self._transcriptCtrl.SetInsertionPoint(
+				self._transcriptCtrl.GetLastPosition(),
+			)
+			self._transcriptCtrl.SetFocus()
+			self._speak(answer)
+		else:
+			msg = err or _("回答失敗")
+			# Translators: Transcript label for an error reply.
+			self._appendTurn(_("錯誤"), msg)
+			self._inputCtrl.SetFocus()
+			self._speak(msg)
+
+	def _onClose(self, evt):
+		global _dlg
+		_dlg = None
+		self.Destroy()
+
+
+_dlg = None
+
+
+def openImageDescriptionDialog(
+	apiCaller,
+	initialContents,
+	initialUserPrompt,
+	initialDescription,
+):
+	"""Show the image-description dialog on the GUI thread (singleton)."""
+
+	def _show():
+		global _dlg
+		if _dlg and _dlg.IsShown():
+			_dlg.Close()
+		_dlg = ImageDescriptionDialog(
+			apiCaller,
+			initialContents,
+			initialUserPrompt,
+			initialDescription,
+		)
+		_dlg.Show()
+		_dlg.Raise()
+
+	wx.CallAfter(_show)

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2103,15 +2103,36 @@ def _captureRegionAsPng(left, top, width, height):
 		return None
 
 
-def _describeImageBytes(pngBytes, timeout=30.0):
-	"""Send PNG image bytes to Google AI and return (description, error_msg).
+def _buildInitialImageContents(pngBytes, prompt=None):
+	"""Build the initial multi-turn ``contents`` payload for image description.
+
+	The returned list contains a single user turn bearing the configured
+	prompt text and the inline PNG bytes, matching the Gemini API schema.
+	"""
+	import base64
+
+	return [
+		{
+			"role": "user",
+			"parts": [
+				{"text": prompt if prompt is not None else _getEffectiveImagePrompt()},
+				{
+					"inline_data": {
+						"mime_type": "image/png",
+						"data": base64.b64encode(pngBytes).decode("ascii"),
+					},
+				},
+			],
+		},
+	]
+
+
+def _callImageDescriptionApi(contents, timeout=30.0):
+	"""Send a pre-built ``contents`` list to Google AI and return (text, error_msg).
 
 	Returns (text, None) on success or (None, error_msg) on failure.
 	"""
-	if not pngBytes:
-		return None, _("無法取得圖片資料")
 	try:
-		import base64
 		import json
 		import urllib.request
 		import urllib.error
@@ -2124,23 +2145,7 @@ def _describeImageBytes(pngBytes, timeout=30.0):
 			model=_getEffectiveImageModel(),
 			key=apiKey,
 		)
-		body = {
-			"contents": [
-				{
-					"parts": [
-						{"text": _getEffectiveImagePrompt()},
-						{
-							"inline_data": {
-								"mime_type": "image/png",
-								"data": base64.b64encode(pngBytes).decode(
-									"ascii",
-								),
-							},
-						},
-					],
-				},
-			],
-		}
+		body = {"contents": contents}
 		req = urllib.request.Request(
 			url,
 			data=json.dumps(body).encode("utf-8"),
@@ -2186,6 +2191,17 @@ def _describeImageBytes(pngBytes, timeout=30.0):
 			exc_info=True,
 		)
 	return None, _("圖片描述失敗")
+
+
+def _describeImageBytes(pngBytes, timeout=30.0):
+	"""Send PNG image bytes to Google AI and return (description, error_msg).
+
+	Returns (text, None) on success or (None, error_msg) on failure.
+	"""
+	if not pngBytes:
+		return None, _("無法取得圖片資料")
+	contents = _buildInitialImageContents(pngBytes)
+	return _callImageDescriptionApi(contents, timeout=timeout)
 
 
 def _getDpiScale(hwnd=None):
@@ -9099,9 +9115,18 @@ class AppModule(appModuleHandler.AppModule):
 		def _worker():
 			import wx
 
-			description, errMsg = _describeImageBytes(pngBytes)
+			prompt = _getEffectiveImagePrompt()
+			initialContents = _buildInitialImageContents(pngBytes, prompt)
+			description, errMsg = _callImageDescriptionApi(initialContents)
 			if description:
-				wx.CallAfter(ui.message, description)
+				from ._imageDescriptionDialog import openImageDescriptionDialog
+
+				openImageDescriptionDialog(
+					_callImageDescriptionApi,
+					initialContents,
+					prompt,
+					description,
+				)
 			else:
 				wx.CallAfter(ui.message, errMsg or _("圖片描述失敗"))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
 Use this file to explain what has changed in your add-on since the previous release. This will be included automatically in the release description when used with GitHub actions.
 
 - 在「LINE Desktop」設定面板新增「圖片描述提示詞」欄位，可自訂傳送給圖片描述模型的提示詞；留空則使用預設值。
+- 圖片描述完成後改以對話視窗呈現結果：描述內容顯示在唯讀多行文字區，NVDA 可用上下方向鍵逐行讀取；並提供後續提問欄位，可針對同一張圖片追問，模型回應會接續加入對話內容，保留多輪上下文。


### PR DESCRIPTION
## Summary

Transforms the image description feature from a simple text-to-speech announcement into an interactive dialog-based system.

- **NVDA browse-mode support**: Description displayed in read-only multiline text control with cursor-key navigation for screen reader access
- **Multi-turn conversation**: Users can ask follow-up questions; Gemini API context is preserved across all replies
- **Speech feedback**: Initial description, loading status, and follow-up responses all announced via NVDA

## What changed

### Code refactoring
- Split monolithic `_describeImageBytes` into:
  - `_buildInitialImageContents(pngBytes, prompt)` — constructs initial Gemini multi-turn payload
  - `_callImageDescriptionApi(contents)` — generic API caller for any contents list
  - `_describeImageBytes(pngBytes)` — backward-compatible wrapper
- Added `addon/appModules/_imageDescriptionDialog.py` with `ImageDescriptionDialog` class and `openImageDescriptionDialog()` function

### Behavior changes
- On NVDA+Windows+I:
  1. "描述圖片中，請稍候" spoken while API processes
  2. Dialog opens showing description in read-only transcript
  3. User can navigate transcript with arrow keys (NVDA reads line-by-line)
  4. User types follow-up question in input field, presses Ctrl+Enter or Send button
  5. "回答中，請稍候…" spoken; API called with full conversation history
  6. Response appended to transcript and announced; focus returns to transcript
  7. Repeat steps 4–6 for additional questions (Escape to close)
- Initial description failure still shows `ui.message()` error (backward compatible)

### Dialog design
- Read-only multiline transcript at top (TE_READONLY) — NVDA navigates with arrow keys
- Status label shows "回答中，請稍候…" while waiting
- Multiline input field for questions (accepts Enter for newline, Ctrl+Enter to send)
- Send button (keyboard shortcut Ctrl+Enter when focus in input) and Close button (Escape)
- Focus management: Transcript on init/after answers; Input re-enabled after response; prevents duplicate sends (`_pending` flag)

### Speech/accessibility
- `_speak(text)` helper calls `speech.cancelSpeech()` then `speech.speakMessage(text)` for clean audio feedback
- Initial description spoken after dialog is shown (via `wx.CallAfter`) to avoid NVDA's focus-change announcement cutting it off
- Follow-up responses announced immediately upon arrival
- Status messages announced to give in-flight feedback

## Test plan

- [ ] NVDA with image description enabled; focus a message with an image
- [ ] Press NVDA+Windows+I; hear "描述圖片中，請稍候"
- [ ] Wait for dialog to open; hear the image description announced
- [ ] Use arrow keys to navigate the transcript; verify NVDA reads content
- [ ] Type a follow-up question (e.g., "這是什麼顏色?"); press Ctrl+Enter
- [ ] Hear "回答中，請稍候…"; wait for response
- [ ] Hear the follow-up answer announced; verify transcript updated
- [ ] Ask another question; verify multi-turn conversation works
- [ ] Press Escape to close dialog
- [ ] Verify no regressions: original image description via `_describeImageBytes` still works if called elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 將圖片描述功能從單次 TTS 公告升級為互動式多輪對話框，透過 `_buildInitialImageContents` / `_callImageDescriptionApi` 重構提升可重用性，並以 `_closed` 旗標解決對話框銷毀後 `wx.CallAfter` 回呼仍存取 widget 的競態條件。整體執行緒模型（主執行緒操作 wx、背景執行緒呼叫 API、`wx.CallAfter` 回傳結果）設計正確，NVDA 朗讀時序亦透過 `wx.CallAfter(self._speak, ...)` 妥善處理。

<h3>Confidence Score: 5/5</h3>

此 PR 可安全合併，所有剩餘問題皆為 P2 層級的 UX 改善建議。

競態條件已透過 _closed 旗標妥善處理，執行緒模型正確，wx 生命週期管理符合慣例。唯一新發現的問題（API 失敗時 Transcript 與模型上下文不一致）屬於 P2 UX 問題，不影響功能正確性或穩定性。

無需特別關注的檔案；_imageDescriptionDialog.py 的 P2 問題可在後續版本改善。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/_imageDescriptionDialog.py | 新增互動式圖片描述對話框，具備多輪對話、NVDA 朗讀及執行緒安全保護；主要邏輯正確，但在 API 失敗時 Transcript 與 self._contents 會產生不一致。 |
| addon/appModules/line.py | 將 _describeImageBytes 重構為三個獨立函式，並更新 _worker 以呼叫新的對話框；API 請求邏輯與執行緒模型保持不變，無明顯問題。 |
| changelog.md | 新增說明圖片描述對話框功能的變更記錄條目。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant NVDA Script
    participant Worker Thread
    participant Gemini API
    participant ImageDescriptionDialog
    participant NVDA Speech

    User->>NVDA Script: 按 NVDA+Windows+I
    NVDA Script->>NVDA Speech: ui.message("描述圖片中，請稍候")
    NVDA Script->>Worker Thread: threading.Thread(target=_worker).start()
    Worker Thread->>Gemini API: _callImageDescriptionApi(initialContents)
    Gemini API-->>Worker Thread: description
    Worker Thread->>ImageDescriptionDialog: wx.CallAfter(openImageDescriptionDialog(...))
    ImageDescriptionDialog->>ImageDescriptionDialog: __init__: 建立 UI、_appendTurn
    ImageDescriptionDialog->>NVDA Speech: wx.CallAfter(_speak, description)

    User->>ImageDescriptionDialog: 輸入後續提問，按 Ctrl+Enter
    ImageDescriptionDialog->>ImageDescriptionDialog: _onSend: _appendTurn, _pending=True
    ImageDescriptionDialog->>NVDA Speech: _speak("回答中，請稍候…")
    ImageDescriptionDialog->>Worker Thread: threading.Thread(target=worker).start()
    Worker Thread->>Gemini API: _apiCaller(followup with full history)
    Gemini API-->>Worker Thread: answer
    Worker Thread->>ImageDescriptionDialog: wx.CallAfter(_onApiResult, question, answer, err)
    ImageDescriptionDialog->>ImageDescriptionDialog: _onApiResult: _appendTurn, _contents updated
    ImageDescriptionDialog->>NVDA Speech: _speak(answer)

    User->>ImageDescriptionDialog: 按 Escape
    ImageDescriptionDialog->>ImageDescriptionDialog: _onCharHook → Close() → _onClose: _closed=True, Destroy()
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2F_imageDescriptionDialog.py%3A152-178%0A**%E5%A4%B1%E6%95%97%E9%87%8D%E8%A9%A6%E6%99%82%E9%80%90%E6%BC%B8%E7%B4%AF%E7%A9%8D%E5%A4%9A%E9%A4%98%E7%9A%84%E3%80%8C%E6%8F%90%E5%95%8F%E3%80%8D%E8%A8%98%E9%8C%84**%0A%0A%60_onSend%60%20%E6%9C%83%E5%85%88%E5%91%BC%E5%8F%AB%20%60_appendTurn%28_%28%22%E6%8F%90%E5%95%8F%22%29%2C%20question%29%60%20%E5%B0%87%E6%8F%90%E5%95%8F%E5%AF%AB%E5%85%A5%20Transcript%EF%BC%8C%E4%BD%86%20%60_onApiResult%60%20%E5%9C%A8%20API%20%E5%A4%B1%E6%95%97%E6%99%82%E4%B8%A6%E4%B8%8D%E6%9C%83%E5%B0%87%E8%A9%B2%E5%95%8F%E9%A1%8C%E5%8A%A0%E5%85%A5%20%60self._contents%60%E3%80%82%E5%9B%A0%E6%AD%A4%E8%8B%A5%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%E5%90%8C%E4%B8%80%E5%95%8F%E9%A1%8C%E4%B8%8A%E5%A4%9A%E6%AC%A1%E9%87%8D%E8%A9%A6%E4%B8%A6%E5%85%A8%E9%83%A8%E5%A4%B1%E6%95%97%EF%BC%8CTranscript%20%E4%B8%AD%E6%9C%83%E5%87%BA%E7%8F%BE%E5%A4%9A%E7%AD%86%E9%87%8D%E8%A4%87%E7%9A%84%E3%80%8C%E6%8F%90%E5%95%8F%E3%80%8D%E8%A8%98%E9%8C%84%EF%BC%8C%E8%80%8C%E6%A8%A1%E5%9E%8B%E4%B8%8A%E4%B8%8B%E6%96%87%EF%BC%88%60self._contents%60%EF%BC%89%E5%8D%BB%E4%B8%80%E7%AD%86%E9%83%BD%E6%B2%92%E6%9C%89%EF%BC%8C%E5%B0%8E%E8%87%B4%20UI%20%E5%91%88%E7%8F%BE%E8%88%87%E5%AF%A6%E9%9A%9B%E5%B0%8D%E8%A9%B1%E6%AD%B7%E5%8F%B2%E5%AE%8C%E5%85%A8%E8%84%AB%E9%89%A4%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda&pr=62&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Freverent-kalam-6a42a0%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Freverent-kalam-6a42a0%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FappModules%2F_imageDescriptionDialog.py%3A152-178%0A**%E5%A4%B1%E6%95%97%E9%87%8D%E8%A9%A6%E6%99%82%E9%80%90%E6%BC%B8%E7%B4%AF%E7%A9%8D%E5%A4%9A%E9%A4%98%E7%9A%84%E3%80%8C%E6%8F%90%E5%95%8F%E3%80%8D%E8%A8%98%E9%8C%84**%0A%0A%60_onSend%60%20%E6%9C%83%E5%85%88%E5%91%BC%E5%8F%AB%20%60_appendTurn%28_%28%22%E6%8F%90%E5%95%8F%22%29%2C%20question%29%60%20%E5%B0%87%E6%8F%90%E5%95%8F%E5%AF%AB%E5%85%A5%20Transcript%EF%BC%8C%E4%BD%86%20%60_onApiResult%60%20%E5%9C%A8%20API%20%E5%A4%B1%E6%95%97%E6%99%82%E4%B8%A6%E4%B8%8D%E6%9C%83%E5%B0%87%E8%A9%B2%E5%95%8F%E9%A1%8C%E5%8A%A0%E5%85%A5%20%60self._contents%60%E3%80%82%E5%9B%A0%E6%AD%A4%E8%8B%A5%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%E5%90%8C%E4%B8%80%E5%95%8F%E9%A1%8C%E4%B8%8A%E5%A4%9A%E6%AC%A1%E9%87%8D%E8%A9%A6%E4%B8%A6%E5%85%A8%E9%83%A8%E5%A4%B1%E6%95%97%EF%BC%8CTranscript%20%E4%B8%AD%E6%9C%83%E5%87%BA%E7%8F%BE%E5%A4%9A%E7%AD%86%E9%87%8D%E8%A4%87%E7%9A%84%E3%80%8C%E6%8F%90%E5%95%8F%E3%80%8D%E8%A8%98%E9%8C%84%EF%BC%8C%E8%80%8C%E6%A8%A1%E5%9E%8B%E4%B8%8A%E4%B8%8B%E6%96%87%EF%BC%88%60self._contents%60%EF%BC%89%E5%8D%BB%E4%B8%80%E7%AD%86%E9%83%BD%E6%B2%92%E6%9C%89%EF%BC%8C%E5%B0%8E%E8%87%B4%20UI%20%E5%91%88%E7%8F%BE%E8%88%87%E5%AF%A6%E9%9A%9B%E5%B0%8D%E8%A9%B1%E6%AD%B7%E5%8F%B2%E5%AE%8C%E5%85%A8%E8%84%AB%E9%89%A4%E3%80%82%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/_imageDescriptionDialog.py
Line: 152-178

Comment:
**失敗重試時逐漸累積多餘的「提問」記錄**

`_onSend` 會先呼叫 `_appendTurn(_("提問"), question)` 將提問寫入 Transcript，但 `_onApiResult` 在 API 失敗時並不會將該問題加入 `self._contents`。因此若使用者在同一問題上多次重試並全部失敗，Transcript 中會出現多筆重複的「提問」記錄，而模型上下文（`self._contents`）卻一筆都沒有，導致 UI 呈現與實際對話歷史完全脫鉤。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix race condition: guard \_onApiResult w..."](https://github.com/keyang556/linedesktopnvda/commit/3ffd288b8a47eb52e9c50bdf86f877e428ac523c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29435511)</sub>

<!-- /greptile_comment -->