### PR TITLE
Add Ollama Cloud support to image description

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -331,7 +331,7 @@ _CALL_OCR_LOG_NOISE_MARKERS = (
 	"WARNING -",
 	"ERROR -",
 	"Traceback",
-	"File \"",
+	'File "',
 	"ConfigManager",
 	"Loading config",
 	"Config loaded",
@@ -1800,24 +1800,43 @@ _currentChatRoomName = None
 # Flag to suppress addon while a file dialog is open
 _suppressAddon = False
 
-# Google AI API key used by NVDA+Windows+I image description.
-# The bundled convenience key is encrypted with a PBKDF2-HMAC-SHA256 derived
+# Image description backend providers exposed in the settings panel.
+_IMAGE_DESCRIPTION_PROVIDER_GOOGLE = "google"
+_IMAGE_DESCRIPTION_PROVIDER_OLLAMA = "ollama"
+_IMAGE_DESCRIPTION_AVAILABLE_PROVIDERS = (
+	_IMAGE_DESCRIPTION_PROVIDER_GOOGLE,
+	_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+)
+_IMAGE_DESCRIPTION_DEFAULT_PROVIDER = _IMAGE_DESCRIPTION_PROVIDER_GOOGLE
+_IMAGE_DESCRIPTION_PROVIDER_LABELS = {
+	_IMAGE_DESCRIPTION_PROVIDER_GOOGLE: "Google AI",
+	_IMAGE_DESCRIPTION_PROVIDER_OLLAMA: "Ollama Cloud",
+}
+_IMAGE_DESCRIPTION_USER_PROVIDER_FILENAME = "line_desktop_image_provider.txt"
+
+# API keys used by NVDA+Windows+I image description.
+# The bundled convenience keys are encrypted with a PBKDF2-HMAC-SHA256 derived
 # keystream plus HMAC integrity tag, using a per-blob random salt, so the
-# ciphertext is opaque to naive string / pattern extraction. It is NOT a
-# cryptographic secret: this is an open-source addon and a determined reader
-# can still recover it by running the decryption code. Its purpose is to
+# ciphertext is opaque to naive string / pattern extraction. They are NOT
+# cryptographic secrets: this is an open-source addon and a determined reader
+# can still recover them by running the decryption code. The purpose is to
 # raise the bar for casual extraction and to spare end-users from having to
-# obtain their own key. Users can override it at any time through the
-# "設定圖片描述 API Key" menu item; their key is persisted (also encrypted)
-# under NVDA's user config directory.
+# obtain their own key. Users can override either key at any time through the
+# settings panel; their key is persisted (also encrypted) under NVDA's user
+# config directory.
 _IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB = (
 	"g+Ku1l+8YmbpO4/JPwy+ZyMlZw4Nfm9gO5bbn8K/vPkz7VFoMRpiFsx2hgfKpUqbxmWqQGo2h8Ph7YjZljEEFkmc3+HlxuE="
 )
+_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_KEY_BLOB = "oLtfHW4hFhTMLQ0mKKcEqd70nU8Z9EsEjjSKfueLCUCnJD9oee2CTd3GtTi0LyS6ZJMuee/jIxFiXDH9kzdyFOMVRfIjMRxJzqZxnccS+p5B1gjbWxYyMLY="
 _IMAGE_DESCRIPTION_USER_KEY_FILENAME = "line_desktop_image_api_key.dat"
+_IMAGE_DESCRIPTION_USER_OLLAMA_KEY_FILENAME = "line_desktop_ollama_api_key.dat"
 _IMAGE_DESCRIPTION_USER_MODEL_FILENAME = "line_desktop_image_model.txt"
+_IMAGE_DESCRIPTION_USER_OLLAMA_MODEL_FILENAME = "line_desktop_ollama_model.txt"
 _IMAGE_DESCRIPTION_USER_PROMPT_FILENAME = "line_desktop_image_prompt.txt"
-# Default model used when the user has not picked one in the settings panel.
+# Default Google model used when the user has not picked one in the settings panel.
 _IMAGE_DESCRIPTION_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
+# Default Ollama Cloud model used when the user has not picked one in the settings panel.
+_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL = "gemini-3-flash-preview:cloud"
 # Models exposed in the settings panel dropdown. The order here is the order
 # the user sees. Strings are the actual model IDs sent to the API endpoint.
 # VERIFY all IDs against: GET https://generativelanguage.googleapis.com/v1beta/models
@@ -1839,9 +1858,17 @@ _IMAGE_DESCRIPTION_AVAILABLE_MODELS = (
 	"gemma-4-31b-it",
 	"gemma-3-27b-it",
 )
+# Vision-capable models commonly available on Ollama Cloud. Users can pick
+# whichever they have access to; unavailable IDs surface as an HTTP error.
+_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS = (
+	"gemini-3-flash-preview:cloud",
+	"qwen3.5:397b-cloud",
+	"gemma4:31b-cloud",
+)
 _IMAGE_DESCRIPTION_ENDPOINT = (
 	"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
 )
+_IMAGE_DESCRIPTION_OLLAMA_ENDPOINT = "https://ollama.com/api/chat"
 _IMAGE_DESCRIPTION_DEFAULT_PROMPT = "請用繁體中文簡要描述這張圖片的內容。"
 # Maximum length accepted from user-supplied prompts, to avoid pathological
 # payloads being sent to the API.
@@ -1856,6 +1883,9 @@ _NOT_COMPUTED = object()
 # Populated once at AppModule.__init__ via _initEffectiveImageApiKey().
 # After that, _getEffectiveImageApiKey() is a pure memory read (no PBKDF2).
 _cachedEffectiveImageApiKey = _NOT_COMPUTED
+_cachedEffectiveOllamaApiKey = _NOT_COMPUTED
+_cachedEffectiveImageProvider = _NOT_COMPUTED
+_cachedEffectiveOllamaModel = _NOT_COMPUTED
 
 
 def _deriveImageApiKeyMaterial(salt, length):
@@ -1972,17 +2002,146 @@ def setUserImageApiKey(plain):
 
 
 def _initEffectiveImageApiKey():
-	"""Decrypt and cache the effective API key. Called once at addon startup."""
+	"""Decrypt and cache the effective Google API key. Called once at addon startup."""
 	global _cachedEffectiveImageApiKey
 	userKey = getUserImageApiKey()
 	_cachedEffectiveImageApiKey = userKey or _deobfuscateImageApiKey(_IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB)
 
 
 def _getEffectiveImageApiKey():
-	"""Return the cached API key; falls back to lazy init if not yet computed."""
+	"""Return the cached Google API key; falls back to lazy init if not yet computed."""
 	if _cachedEffectiveImageApiKey is _NOT_COMPUTED:
 		_initEffectiveImageApiKey()
 	return _cachedEffectiveImageApiKey
+
+
+def _getOllamaApiKeyStorePath():
+	"""Return the filesystem path for the user-supplied Ollama API key file."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_OLLAMA_KEY_FILENAME)
+
+
+def getUserOllamaApiKey():
+	"""Return the plain Ollama API key previously set by the user, or None."""
+	path = _getOllamaApiKeyStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			blob = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user Ollama API key: {e}", exc_info=True)
+		return None
+	return _deobfuscateImageApiKey(blob)
+
+
+def setUserOllamaApiKey(plain):
+	"""Persist a user-supplied Ollama API key (obfuscated). Empty/None clears it."""
+	global _cachedEffectiveOllamaApiKey
+	path = _getOllamaApiKeyStorePath()
+	if not path:
+		return False
+	try:
+		if not plain:
+			if os.path.isfile(path):
+				os.remove(path)
+			_cachedEffectiveOllamaApiKey = _deobfuscateImageApiKey(_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_KEY_BLOB)
+		else:
+			blob = _obfuscateImageApiKey(plain)
+			with open(path, "w", encoding="utf-8") as f:
+				f.write(blob)
+			_cachedEffectiveOllamaApiKey = plain
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user Ollama API key: {e}", exc_info=True)
+		return False
+
+
+def _initEffectiveOllamaApiKey():
+	"""Decrypt and cache the effective Ollama API key."""
+	global _cachedEffectiveOllamaApiKey
+	userKey = getUserOllamaApiKey()
+	_cachedEffectiveOllamaApiKey = userKey or _deobfuscateImageApiKey(
+		_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_KEY_BLOB
+	)
+
+
+def _getEffectiveOllamaApiKey():
+	"""Return the cached Ollama API key; falls back to lazy init if not yet computed."""
+	if _cachedEffectiveOllamaApiKey is _NOT_COMPUTED:
+		_initEffectiveOllamaApiKey()
+	return _cachedEffectiveOllamaApiKey
+
+
+def _getImageProviderStorePath():
+	"""Return the filesystem path for the user-selected provider preference."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_PROVIDER_FILENAME)
+
+
+def getUserImageProvider():
+	"""Return the provider ID previously chosen by the user, or None."""
+	path = _getImageProviderStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			value = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user image provider: {e}", exc_info=True)
+		return None
+	if not value:
+		return None
+	if value not in _IMAGE_DESCRIPTION_AVAILABLE_PROVIDERS:
+		log.debug(f"LINE: stored image provider {value!r} is not in the allowed list")
+		return None
+	return value
+
+
+def setUserImageProvider(provider):
+	"""Persist the user-selected provider. Empty/None or default clears the file."""
+	global _cachedEffectiveImageProvider
+	path = _getImageProviderStorePath()
+	if not path:
+		return False
+	try:
+		if not provider or provider == _IMAGE_DESCRIPTION_DEFAULT_PROVIDER:
+			if os.path.isfile(path):
+				os.remove(path)
+			_cachedEffectiveImageProvider = _IMAGE_DESCRIPTION_DEFAULT_PROVIDER
+			return True
+		if provider not in _IMAGE_DESCRIPTION_AVAILABLE_PROVIDERS:
+			log.warning(f"LINE: refusing to save unknown image provider {provider!r}")
+			return False
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(provider)
+		_cachedEffectiveImageProvider = provider
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user image provider: {e}", exc_info=True)
+		return False
+
+
+def _getEffectiveImageProvider():
+	"""Return the cached provider ID; lazily resolved from disk on first call."""
+	global _cachedEffectiveImageProvider
+	if _cachedEffectiveImageProvider is _NOT_COMPUTED:
+		_cachedEffectiveImageProvider = getUserImageProvider() or _IMAGE_DESCRIPTION_DEFAULT_PROVIDER
+	return _cachedEffectiveImageProvider
 
 
 def _getImageModelStorePath():
@@ -2050,6 +2209,70 @@ def _getEffectiveImageModel():
 	if _cachedEffectiveImageModel is _NOT_COMPUTED:
 		_cachedEffectiveImageModel = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
 	return _cachedEffectiveImageModel
+
+
+def _getOllamaModelStorePath():
+	"""Return the filesystem path for the user-selected Ollama model preference."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_OLLAMA_MODEL_FILENAME)
+
+
+def getUserOllamaModel():
+	"""Return the Ollama model ID previously chosen by the user, or None."""
+	path = _getOllamaModelStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			value = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user Ollama model: {e}", exc_info=True)
+		return None
+	if not value:
+		return None
+	if value not in _IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS:
+		log.debug(f"LINE: stored Ollama model {value!r} is not in the allowed list")
+		return None
+	return value
+
+
+def setUserOllamaModel(name):
+	"""Persist a user-selected Ollama model. Empty/None or default clears the file."""
+	global _cachedEffectiveOllamaModel
+	path = _getOllamaModelStorePath()
+	if not path:
+		return False
+	try:
+		if not name or name == _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL:
+			if os.path.isfile(path):
+				os.remove(path)
+			_cachedEffectiveOllamaModel = _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL
+			return True
+		if name not in _IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS:
+			log.warning(f"LINE: refusing to save unknown Ollama model {name!r}")
+			return False
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(name)
+		_cachedEffectiveOllamaModel = name
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user Ollama model: {e}", exc_info=True)
+		return False
+
+
+def _getEffectiveOllamaModel():
+	"""Return the cached Ollama model ID; lazily resolved from disk on first call."""
+	global _cachedEffectiveOllamaModel
+	if _cachedEffectiveOllamaModel is _NOT_COMPUTED:
+		_cachedEffectiveOllamaModel = getUserOllamaModel() or _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL
+	return _cachedEffectiveOllamaModel
 
 
 def _getImagePromptStorePath():
@@ -2245,7 +2468,28 @@ def _buildInitialImageContents(pngBytes, prompt=None):
 	]
 
 
-def _callImageDescriptionApi(contents, timeout=30.0):
+def _callImageDescriptionApi(contents, timeout=None):
+	"""Dispatch a pre-built ``contents`` list to the active provider.
+
+	Returns (text, None) on success or (None, error_msg) on failure. The
+	provider is resolved at call time, so changing the setting mid-conversation
+	switches subsequent turns to the new backend. When ``timeout`` is None,
+	each backend uses its own appropriate default (30 s for Google, 60 s for
+	Ollama Cloud which typically needs more time).
+	"""
+	provider = _getEffectiveImageProvider()
+	if provider == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
+		return _callOllamaImageDescriptionApi(
+			contents,
+			timeout=timeout if timeout is not None else 60.0,
+		)
+	return _callGoogleImageDescriptionApi(
+		contents,
+		timeout=timeout if timeout is not None else 30.0,
+	)
+
+
+def _callGoogleImageDescriptionApi(contents, timeout=30.0):
 	"""Send a pre-built ``contents`` list to Google AI and return (text, error_msg).
 
 	Returns (text, None) on success or (None, error_msg) on failure.
@@ -2311,8 +2555,105 @@ def _callImageDescriptionApi(contents, timeout=30.0):
 	return None, _("圖片描述失敗")
 
 
-def _describeImageBytes(pngBytes, timeout=30.0):
-	"""Send PNG image bytes to Google AI and return (description, error_msg).
+def _geminiContentsToOllamaMessages(contents):
+	"""Convert the canonical Gemini-shaped contents into Ollama chat messages.
+
+	The dialog stores history as Gemini turns ({"role": "user"|"model",
+	"parts": [{"text": ...}, {"inline_data": {...}}]}). Ollama's /api/chat
+	expects {"role": "user"|"assistant", "content": str, "images": [b64]}.
+	"""
+	messages = []
+	for turn in contents or []:
+		role = turn.get("role") if isinstance(turn, dict) else None
+		ollamaRole = "assistant" if role == "model" else "user"
+		texts = []
+		images = []
+		for part in (turn.get("parts") or []) if isinstance(turn, dict) else []:
+			if not isinstance(part, dict):
+				continue
+			if "text" in part and part["text"]:
+				texts.append(part["text"])
+			elif "inline_data" in part:
+				inline = part.get("inline_data") or {}
+				data = inline.get("data")
+				if data:
+					images.append(data)
+		message = {"role": ollamaRole, "content": "\n".join(texts)}
+		if images:
+			message["images"] = images
+		messages.append(message)
+	return messages
+
+
+def _callOllamaImageDescriptionApi(contents, timeout=60.0):
+	"""Send the canonical contents to Ollama Cloud's /api/chat endpoint.
+
+	Returns (text, None) on success or (None, error_msg) on failure. Uses a
+	longer default timeout because cloud-hosted vision models can take noticeably
+	longer than Google's flash variants to produce a first response.
+	"""
+	try:
+		import json
+		import urllib.request
+		import urllib.error
+
+		apiKey = _getEffectiveOllamaApiKey()
+		if not apiKey:
+			log.warning("LINE: no Ollama Cloud API key available")
+			return None, _("未設定 API Key")
+		messages = _geminiContentsToOllamaMessages(contents)
+		body = {
+			"model": _getEffectiveOllamaModel(),
+			"messages": messages,
+			"stream": False,
+		}
+		req = urllib.request.Request(
+			_IMAGE_DESCRIPTION_OLLAMA_ENDPOINT,
+			data=json.dumps(body).encode("utf-8"),
+			headers={
+				"Content-Type": "application/json",
+				"Authorization": f"Bearer {apiKey}",
+				"Accept": "application/json",
+			},
+			method="POST",
+		)
+		try:
+			with urllib.request.urlopen(req, timeout=timeout) as resp:
+				raw = resp.read()
+		except urllib.error.HTTPError as e:
+			errBody = e.read().decode("utf-8", errors="replace")
+			log.warning(
+				f"LINE: Ollama image description HTTP {e.code} {e.reason}: {errBody[:500]}",
+			)
+			return None, _("圖片描述失敗 (HTTP {code})").format(code=e.code)
+		except Exception as e:
+			log.warning(f"LINE: Ollama image description network error: {e}", exc_info=True)
+			return None, _("圖片描述失敗 (網路錯誤)")
+		data = json.loads(raw.decode("utf-8", errors="replace"))
+	except Exception as e:
+		log.warning(
+			f"LINE: Ollama image description request failed: {e}",
+			exc_info=True,
+		)
+		return None, _("圖片描述失敗")
+
+	try:
+		message = data.get("message") if isinstance(data, dict) else None
+		if isinstance(message, dict):
+			text = message.get("content")
+			if text:
+				return text.strip(), None
+		log.info(f"LINE: Ollama image description returned no content: {data!r}")
+	except Exception as e:
+		log.warning(
+			f"LINE: Ollama image description response parse failed: {e}",
+			exc_info=True,
+		)
+	return None, _("圖片描述失敗 (無回應)")
+
+
+def _describeImageBytes(pngBytes, timeout=None):
+	"""Send PNG image bytes to the active image-description provider and return (description, error_msg).
 
 	Returns (text, None) on success or (None, error_msg) on failure.
 	"""
@@ -3941,8 +4282,7 @@ def _queryAndSpeakUIAFocus():
 			if isMessageItem:
 				if not _isElementVisibleInForegroundWindow(targetElement):
 					log.debug(
-						f"LINE UIA focus: skipping off-window message ListItem "
-						f"runtimeId={elementId}",
+						f"LINE UIA focus: skipping off-window message ListItem runtimeId={elementId}",
 					)
 					return
 				log.info(
@@ -4342,8 +4682,7 @@ def _copyAndReadMessage(targetElement):
 			targetRuntimeId,
 		):
 			log.info(
-				f"LINE: copy-read skipping probe over edit field "
-				f"at ({clickX}, {clickY}) [{posLabel}]",
+				f"LINE: copy-read skipping probe over edit field at ({clickX}, {clickY}) [{posLabel}]",
 			)
 			core.callLater(50, lambda: _attemptCopyAtOffset(posIdx + 1))
 			return
@@ -5259,9 +5598,10 @@ class AppModule(appModuleHandler.AppModule):
 		self._lineVersion = _readLineVersion()
 		self._lineLanguage = _readLineLanguage()
 		self._qtAccessibleSet = _isQtAccessibleSet()
-		# Decrypt the image API key once at startup so PBKDF2 never runs
+		# Decrypt the image API keys once at startup so PBKDF2 never runs
 		# during an actual image-description request.
 		_initEffectiveImageApiKey()
+		_initEffectiveOllamaApiKey()
 		log.info(
 			f"LINE AppModule loaded for process: {self.processID}, "
 			f"exe: {self.appName}, "
@@ -8739,8 +9079,7 @@ class AppModule(appModuleHandler.AppModule):
 				targetRuntimeId,
 			):
 				log.info(
-					f"LINE: skipping {actionName} probe over edit field "
-					f"at ({clickX}, {clickY}) [{posLabel}]",
+					f"LINE: skipping {actionName} probe over edit field at ({clickX}, {clickY}) [{posLabel}]",
 				)
 				core.callLater(50, lambda: _attemptAtOffset(posIdx + 1))
 				return
@@ -9314,7 +9653,7 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		gesture="kb:NVDA+windows+i",
 		# Translators: Input help message for the image-description command.
-		description=_("Describe the current image message using Google AI"),
+		description=_("使用設定的 AI 服務描述目前的圖片訊息"),
 		category="LINE",
 	)
 	def script_describeImage(self, gesture):
@@ -10745,8 +11084,7 @@ class AppModule(appModuleHandler.AppModule):
 				targetRuntimeId,
 			):
 				log.info(
-					f"LINE: skipping context menu probe over edit field "
-					f"at ({clickX}, {clickY}) [{posLabel}]",
+					f"LINE: skipping context menu probe over edit field at ({clickX}, {clickY}) [{posLabel}]",
 				)
 				core.callLater(50, lambda: _attemptAtOffset(posIdx + 1))
 				return

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -108,28 +108,40 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		self._qtCheck = sHelper.addItem(wx.CheckBox(self, label=qtLabel))
 		self._qtCheck.SetValue(_isQtAccessibleSet())
 
+		providerOptions = self._loadProviderOptions()
+		self._providerIds = tuple(opt[0] for opt in providerOptions)
+		providerLabels = [opt[1] for opt in providerOptions]
+		# Translators: Dropdown label for selecting the image-description backend provider.
+		providerLabel = _("圖片描述服務 (&D)")
+		self._providerChoice = sHelper.addLabeledControl(
+			providerLabel,
+			wx.Choice,
+			choices=providerLabels,
+		)
+		currentProvider = self._loadCurrentProvider()
+		try:
+			providerIndex = self._providerIds.index(currentProvider)
+		except ValueError:
+			providerIndex = 0
+		if self._providerIds:
+			self._providerChoice.SetSelection(providerIndex)
+
+		# Pending edits per-provider so switching the dropdown doesn't lose
+		# in-flight changes the user has made for the other backend.
+		self._pendingApiKey = {pid: self._loadStoredApiKey(pid) for pid in self._providerIds}
+		self._pendingModel = {pid: self._loadStoredModel(pid) for pid in self._providerIds}
+
 		# Translators: Text field label for the image-description API key
 		apiLabel = _("圖片描述 API Key，留空則使用預設金鑰 (&I)")
 		self._apiKeyText = sHelper.addLabeledControl(apiLabel, wx.TextCtrl)
-		self._apiKeyText.SetValue(self._loadCurrentApiKey())
 
-		self._modelChoices, defaultModel, currentModel = self._loadModelOptions()
 		# Translators: Dropdown label for selecting the image-description model
 		modelLabel = _("圖片描述模型 (&M)")
 		self._modelChoice = sHelper.addLabeledControl(
 			modelLabel,
 			wx.Choice,
-			choices=list(self._modelChoices),
+			choices=[],
 		)
-		try:
-			selectIndex = self._modelChoices.index(currentModel)
-		except ValueError:
-			try:
-				selectIndex = self._modelChoices.index(defaultModel)
-			except ValueError:
-				selectIndex = 0
-		if self._modelChoices:
-			self._modelChoice.SetSelection(selectIndex)
 
 		# Translators: Text field label for the image-description prompt
 		promptLabel = _("圖片描述提示詞，留空則使用預設 (&P)")
@@ -141,33 +153,150 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		)
 		self._promptText.SetValue(self._loadCurrentPrompt())
 
-	def _loadCurrentApiKey(self):
-		try:
-			from appModules.line import getUserImageApiKey
+		self._activeProviderId = self._currentSelectedProviderId() or _safeDefaultProvider()
+		self._refreshProviderUI(self._activeProviderId)
 
+		self._providerChoice.Bind(wx.EVT_CHOICE, self._onProviderChange)
+
+	def _currentSelectedProviderId(self):
+		"""Return the provider ID matching the dropdown selection, or None."""
+		idx = self._providerChoice.GetSelection() if hasattr(self, "_providerChoice") else wx.NOT_FOUND
+		if idx == wx.NOT_FOUND or not self._providerIds:
+			return None
+		if 0 <= idx < len(self._providerIds):
+			return self._providerIds[idx]
+		return None
+
+	def _onProviderChange(self, evt):
+		# Stash whatever the user has typed/selected for the previously active
+		# provider before we repaint the controls for the newly selected one.
+		previous = getattr(self, "_activeProviderId", None)
+		if previous and previous in self._pendingApiKey:
+			self._pendingApiKey[previous] = self._apiKeyText.GetValue().strip()
+		if previous and previous in self._pendingModel:
+			selectedModel = self._currentModelChoiceValue()
+			if selectedModel is not None:
+				self._pendingModel[previous] = selectedModel
+
+		newProvider = self._currentSelectedProviderId() or previous
+		self._activeProviderId = newProvider
+		self._refreshProviderUI(newProvider)
+
+	def _currentModelChoiceValue(self):
+		choices = getattr(self, "_modelChoices", ())
+		idx = self._modelChoice.GetSelection()
+		if idx == wx.NOT_FOUND or not choices:
+			return None
+		if 0 <= idx < len(choices):
+			return choices[idx]
+		return None
+
+	def _refreshProviderUI(self, provider):
+		"""Repopulate the API-key text field and the model dropdown for ``provider``."""
+		choices, defaultModel = self._modelOptionsFor(provider)
+		self._modelChoices = choices
+		self._modelChoice.Clear()
+		if choices:
+			self._modelChoice.AppendItems(list(choices))
+		desiredModel = self._pendingModel.get(provider) or defaultModel
+		try:
+			selectIndex = choices.index(desiredModel)
+		except ValueError:
+			try:
+				selectIndex = choices.index(defaultModel)
+			except ValueError:
+				selectIndex = 0
+		if choices:
+			self._modelChoice.SetSelection(selectIndex)
+
+		self._apiKeyText.ChangeValue(self._pendingApiKey.get(provider, ""))
+
+	def _loadProviderOptions(self):
+		"""Return [(provider_id, display_label), …] in the order shown to the user."""
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_AVAILABLE_PROVIDERS,
+				_IMAGE_DESCRIPTION_PROVIDER_LABELS,
+			)
+
+			return [
+				(pid, _IMAGE_DESCRIPTION_PROVIDER_LABELS.get(pid, pid))
+				for pid in _IMAGE_DESCRIPTION_AVAILABLE_PROVIDERS
+			]
+		except Exception:
+			log.debug("LINE: cannot load provider options", exc_info=True)
+			return []
+
+	def _loadCurrentProvider(self):
+		try:
+			from appModules.line import getUserImageProvider
+
+			return getUserImageProvider() or _safeDefaultProvider()
+		except Exception:
+			log.debug("LINE: cannot load current image provider", exc_info=True)
+			return _safeDefaultProvider()
+
+	def _loadStoredApiKey(self, provider):
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				getUserImageApiKey,
+				getUserOllamaApiKey,
+			)
+
+			if provider == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
+				return getUserOllamaApiKey() or ""
 			return getUserImageApiKey() or ""
 		except Exception:
-			log.debug("LINE: cannot load user API key for settings panel", exc_info=True)
+			log.debug(
+				f"LINE: cannot load API key for provider {provider!r}",
+				exc_info=True,
+			)
 			return ""
 
-	def _loadModelOptions(self):
-		"""Return (choices_tuple, default_model_id, currently_selected_model_id)."""
+	def _loadStoredModel(self, provider):
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				getUserImageModel,
+				getUserOllamaModel,
+			)
+
+			if provider == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
+				return getUserOllamaModel() or _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL
+			return getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
+		except Exception:
+			log.debug(
+				f"LINE: cannot load model for provider {provider!r}",
+				exc_info=True,
+			)
+			return ""
+
+	def _modelOptionsFor(self, provider):
+		"""Return (choices_tuple, default_model_id) for the given provider."""
 		try:
 			from appModules.line import (
 				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
 				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
-				getUserImageModel,
+				_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS,
+				_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
 			)
 
-			current = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
+			if provider == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
+				return (
+					_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS,
+					_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
+				)
 			return (
 				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
 				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
-				current,
 			)
 		except Exception:
 			log.debug("LINE: cannot load image model options", exc_info=True)
-			return ((), "", "")
+			return ((), "")
 
 	def _loadCurrentPrompt(self):
 		try:
@@ -195,21 +324,61 @@ class LineDesktopSettingsPanel(SettingsPanel):
 					self,
 				)
 
-		# Image description API key
-		try:
-			from appModules.line import getUserImageApiKey, setUserImageApiKey
+		# Capture pending edits for the currently visible provider before saving.
+		activeProvider = self._currentSelectedProviderId() or _safeDefaultProvider()
+		if activeProvider in self._pendingApiKey:
+			self._pendingApiKey[activeProvider] = self._apiKeyText.GetValue().strip()
+		if activeProvider in self._pendingModel:
+			selectedModel = self._currentModelChoiceValue()
+			if selectedModel is not None:
+				self._pendingModel[activeProvider] = selectedModel
 
-			newKey = self._apiKeyText.GetValue().strip()
-			currentKey = getUserImageApiKey() or ""
-			if newKey != currentKey:
-				if not setUserImageApiKey(newKey):
+		# Active provider selection
+		try:
+			from appModules.line import getUserImageProvider, setUserImageProvider
+
+			currentProvider = getUserImageProvider() or _safeDefaultProvider()
+			if activeProvider != currentProvider:
+				if not setUserImageProvider(activeProvider):
 					gui.messageBox(
-						# Translators: Error shown when saving the image API key fails
-						_("儲存圖片描述 API Key 失敗，請重試。"),
+						# Translators: Error shown when saving the provider fails
+						_("儲存圖片描述服務失敗，請重試。"),
 						_("LINE Desktop - 設定錯誤"),
 						wx.OK | wx.ICON_ERROR,
 						self,
 					)
+		except Exception:
+			log.warning(
+				"LINE: cannot load image provider helpers from settings panel",
+				exc_info=True,
+			)
+
+		# Image description API keys (one per provider)
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				getUserImageApiKey,
+				getUserOllamaApiKey,
+				setUserImageApiKey,
+				setUserOllamaApiKey,
+			)
+
+			for providerId, pendingKey in self._pendingApiKey.items():
+				if providerId == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
+					currentKey = getUserOllamaApiKey() or ""
+					setter = setUserOllamaApiKey
+				else:
+					currentKey = getUserImageApiKey() or ""
+					setter = setUserImageApiKey
+				if pendingKey != currentKey:
+					if not setter(pendingKey):
+						gui.messageBox(
+							# Translators: Error shown when saving the image API key fails
+							_("儲存圖片描述 API Key 失敗，請重試。"),
+							_("LINE Desktop - 設定錯誤"),
+							wx.OK | wx.ICON_ERROR,
+							self,
+						)
 		except Exception:
 			log.warning(
 				"LINE: cannot load image API key helpers from settings panel",
@@ -223,20 +392,29 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				self,
 			)
 
-		# Image description model
+		# Image description models (one per provider)
 		try:
 			from appModules.line import (
 				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
 				getUserImageModel,
+				getUserOllamaModel,
 				setUserImageModel,
+				setUserOllamaModel,
 			)
 
-			selectedIndex = self._modelChoice.GetSelection()
-			if selectedIndex != wx.NOT_FOUND and self._modelChoices:
-				newModel = self._modelChoices[selectedIndex]
-				currentModel = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
-				if newModel != currentModel:
-					if not setUserImageModel(newModel):
+			for providerId, pendingModel in self._pendingModel.items():
+				if not pendingModel:
+					continue
+				if providerId == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
+					currentModel = getUserOllamaModel() or _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL
+					setter = setUserOllamaModel
+				else:
+					currentModel = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
+					setter = setUserImageModel
+				if pendingModel != currentModel:
+					if not setter(pendingModel):
 						gui.messageBox(
 							# Translators: Error shown when saving the image model fails
 							_("儲存圖片描述模型失敗，請重試。"),
@@ -274,6 +452,16 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				"LINE: cannot load image prompt helpers from settings panel",
 				exc_info=True,
 			)
+
+
+def _safeDefaultProvider():
+	"""Return the default provider ID, falling back to a literal if line.py is unavailable."""
+	try:
+		from appModules.line import _IMAGE_DESCRIPTION_DEFAULT_PROVIDER
+
+		return _IMAGE_DESCRIPTION_DEFAULT_PROVIDER
+	except Exception:
+		return "google"
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):


### PR DESCRIPTION
## Summary

Adds Ollama Cloud as a second backend for the image description feature (NVDA+Windows+I), alongside the existing Google AI integration. Users can now switch between providers in the LINE Desktop settings panel.

- **Provider dropdown**: First control lets users choose Google AI or Ollama Cloud
- **API key & model per provider**: Switching providers dynamically repopulates the API key field and model selector
- **Multi-turn conversations**: Dialog history is stored in canonical Gemini format and converted to Ollama's chat format on demand
- **Encrypted defaults**: Both APIs come with bundled, encrypted convenience keys (Google's existing key + Ollama's `8a52734c...`)

## Ollama Cloud Configuration

- **Endpoint**: `https://ollama.com/api/chat` with Bearer token auth
- **Default model**: `gemini-3-flash-preview:cloud`
- **Available models**: `gemini-3-flash-preview:cloud`, `qwen3.5:397b-cloud`, `gemma4:31b-cloud`

All settings are per-provider and persisted separately under NVDA's user config directory.

## Test Plan

- [x] Syntax check: Python compiles without errors
- [x] Unit tests: All 85 existing tests pass
- [x] Conversion: Gemini message history converts correctly to Ollama format
- [x] Round-trip: Encrypted Ollama key decrypts to original plaintext

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 為圖片描述功能（NVDA+Windows+I）新增 Ollama Cloud 作為第二個後端，並在設定面板加入 provider 下拉選單，讓使用者可在 Google AI 與 Ollama Cloud 之間切換，且每個 provider 的 API key 與模型選擇分別儲存。前次 code review 指出的 60 秒 timeout 與 docstring 問題均已修正。

<h3>Confidence Score: 5/5</h3>

可安全合併；先前 P1 問題已解決，剩餘意見均為 P2 防禦性建議。

前次 review 指出的 timeout 覆蓋（P1）與過時 docstring 問題均已在此版本中完整修正。新增的 Ollama 整合邏輯結構清晰，settings panel 的 per-provider 暫存機制設計正確。僅剩 elif 防禦性建議與 model 清單驗證透明度兩項 P2 建議，不影響合併。

無需特別關注的檔案；所有變更均已仔細審查。

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 Ollama Cloud provider 支援：新增 API key 與模型管理函式、`_geminiContentsToOllamaMessages` 格式轉換、`_callOllamaImageDescriptionApi`，以及重構後的 `_callImageDescriptionApi` dispatch 函式；timeout 問題（前次 P1）已修正，預設值改為 60 s（Ollama）/30 s（Google）。 |
| addon/globalPlugins/lineDesktopHelper.py | 設定面板升級為每個 provider 各自管理 API key 與模型；新增 provider 下拉選單、`_pendingApiKey`/`_pendingModel` 暫存機制，以及 `_refreshProviderUI` 動態切換 UI；`onSave` 改為對每個 provider 各自比對並儲存。 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as 使用者（NVDA+Win+I）
    participant Script as script_describeImage
    participant Dispatch as _callImageDescriptionApi
    participant Provider as _getEffectiveImageProvider
    participant Google as _callGoogleImageDescriptionApi
    participant Ollama as _callOllamaImageDescriptionApi
    participant Convert as _geminiContentsToOllamaMessages

    User->>Script: 按下快速鍵
    Script->>Dispatch: contents, timeout=None
    Dispatch->>Provider: 取得目前 provider
    Provider-->>Dispatch: google 或 ollama

    alt provider == google
        Dispatch->>Google: contents, timeout=30.0
        Google-->>Dispatch: (text, None) 或 (None, err)
    else provider == ollama
        Dispatch->>Convert: contents (Gemini 格式)
        Convert-->>Dispatch: messages (Ollama 格式)
        Dispatch->>Ollama: messages, timeout=60.0
        Ollama->>Ollama: POST https://ollama.com/api/chat
        Ollama-->>Dispatch: (text, None) 或 (None, err)
    end

    Dispatch-->>Script: (description, error_msg)
    Script-->>User: 語音播報結果
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `addon/appModules/line.py`, line 9655 ([link](https://github.com/keyang556/linedesktopnvda/blob/7faa49b9c7ba81dddbbce4c55c7b22e2d426a44a/addon/appModules/line.py#L9655)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **使用者可見的 Script 說明文字仍寫「Google AI」**

   `description` 參數會顯示在 NVDA「輸入手勢」對話框中，供使用者查看。加入 Ollama Cloud 後，此文字已不正確，使用者看到的依舊是「Google AI」。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: addon/appModules/line.py
   Line: 9655

   Comment:
   **使用者可見的 Script 說明文字仍寫「Google AI」**

   `description` 參數會顯示在 NVDA「輸入手勢」對話框中，供使用者查看。加入 Ollama Cloud 後，此文字已不正確，使用者看到的依舊是「Google AI」。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%209655%0A%0AComment%3A%0A**%E4%BD%BF%E7%94%A8%E8%80%85%E5%8F%AF%E8%A6%8B%E7%9A%84%20Script%20%E8%AA%AA%E6%98%8E%E6%96%87%E5%AD%97%E4%BB%8D%E5%AF%AB%E3%80%8CGoogle%20AI%E3%80%8D**%0A%0A%60description%60%20%E5%8F%83%E6%95%B8%E6%9C%83%E9%A1%AF%E7%A4%BA%E5%9C%A8%20NVDA%E3%80%8C%E8%BC%B8%E5%85%A5%E6%89%8B%E5%8B%A2%E3%80%8D%E5%B0%8D%E8%A9%B1%E6%A1%86%E4%B8%AD%EF%BC%8C%E4%BE%9B%E4%BD%BF%E7%94%A8%E8%80%85%E6%9F%A5%E7%9C%8B%E3%80%82%E5%8A%A0%E5%85%A5%20Ollama%20Cloud%20%E5%BE%8C%EF%BC%8C%E6%AD%A4%E6%96%87%E5%AD%97%E5%B7%B2%E4%B8%8D%E6%AD%A3%E7%A2%BA%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E7%9C%8B%E5%88%B0%E7%9A%84%E4%BE%9D%E8%88%8A%E6%98%AF%E3%80%8CGoogle%20AI%E3%80%8D%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09description%3D_%28%22Describe%20the%20current%20image%20message%20using%20the%20configured%20AI%20provider%22%29%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=keyang556%2Flinedesktopnvda&pr=65&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Ffervent-haibt-076fc8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Ffervent-haibt-076fc8%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%209655%0A%0AComment%3A%0A**%E4%BD%BF%E7%94%A8%E8%80%85%E5%8F%AF%E8%A6%8B%E7%9A%84%20Script%20%E8%AA%AA%E6%98%8E%E6%96%87%E5%AD%97%E4%BB%8D%E5%AF%AB%E3%80%8CGoogle%20AI%E3%80%8D**%0A%0A%60description%60%20%E5%8F%83%E6%95%B8%E6%9C%83%E9%A1%AF%E7%A4%BA%E5%9C%A8%20NVDA%E3%80%8C%E8%BC%B8%E5%85%A5%E6%89%8B%E5%8B%A2%E3%80%8D%E5%B0%8D%E8%A9%B1%E6%A1%86%E4%B8%AD%EF%BC%8C%E4%BE%9B%E4%BD%BF%E7%94%A8%E8%80%85%E6%9F%A5%E7%9C%8B%E3%80%82%E5%8A%A0%E5%85%A5%20Ollama%20Cloud%20%E5%BE%8C%EF%BC%8C%E6%AD%A4%E6%96%87%E5%AD%97%E5%B7%B2%E4%B8%8D%E6%AD%A3%E7%A2%BA%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E7%9C%8B%E5%88%B0%E7%9A%84%E4%BE%9D%E8%88%8A%E6%98%AF%E3%80%8CGoogle%20AI%E3%80%8D%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09description%3D_%28%22Describe%20the%20current%20image%20message%20using%20the%20configured%20AI%20provider%22%29%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `addon/appModules/line.py`, line 2651-2661 ([link](https://github.com/keyang556/linedesktopnvda/blob/7c442590a900c3d686631217b2bfa88f18bbcdc8/addon/appModules/line.py#L2651-L2661)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **語法錯誤：Docstring 結尾重複，導致插件無法載入**

   PR 作者在更新 docstring 首行時，多插入了一組 `Returns...` 與 `"""` 行，但原本的這兩行仍保留（屬 diff 中的 context 行，未被刪除）。結果函式內出現兩個 `"""` 結尾：第一個正確關閉 docstring，第二個卻在函式體內開啟一個新的三引號字串常量，把 `if not pngBytes:` 以下的所有程式碼都包進字串裡，並一路消耗到 `_getDpiScale` 的 docstring 開頭才關閉。這直接導致 `SyntaxError: unterminated string literal`——Python 實際驗證（`ast.parse`）已確認此錯誤，插件整體無法載入。

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: addon/appModules/line.py
   Line: 2651-2661

   Comment:
   **語法錯誤：Docstring 結尾重複，導致插件無法載入**

   PR 作者在更新 docstring 首行時，多插入了一組 `Returns...` 與 `"""` 行，但原本的這兩行仍保留（屬 diff 中的 context 行，未被刪除）。結果函式內出現兩個 `"""` 結尾：第一個正確關閉 docstring，第二個卻在函式體內開啟一個新的三引號字串常量，把 `if not pngBytes:` 以下的所有程式碼都包進字串裡，並一路消耗到 `_getDpiScale` 的 docstring 開頭才關閉。這直接導致 `SyntaxError: unterminated string literal`——Python 實際驗證（`ast.parse`）已確認此錯誤，插件整體無法載入。

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%202651-2661%0A%0AComment%3A%0A**%E8%AA%9E%E6%B3%95%E9%8C%AF%E8%AA%A4%EF%BC%9ADocstring%20%E7%B5%90%E5%B0%BE%E9%87%8D%E8%A4%87%EF%BC%8C%E5%B0%8E%E8%87%B4%E6%8F%92%E4%BB%B6%E7%84%A1%E6%B3%95%E8%BC%89%E5%85%A5**%0A%0APR%20%E4%BD%9C%E8%80%85%E5%9C%A8%E6%9B%B4%E6%96%B0%20docstring%20%E9%A6%96%E8%A1%8C%E6%99%82%EF%BC%8C%E5%A4%9A%E6%8F%92%E5%85%A5%E4%BA%86%E4%B8%80%E7%B5%84%20%60Returns...%60%20%E8%88%87%20%60%22%22%22%60%20%E8%A1%8C%EF%BC%8C%E4%BD%86%E5%8E%9F%E6%9C%AC%E7%9A%84%E9%80%99%E5%85%A9%E8%A1%8C%E4%BB%8D%E4%BF%9D%E7%95%99%EF%BC%88%E5%B1%AC%20diff%20%E4%B8%AD%E7%9A%84%20context%20%E8%A1%8C%EF%BC%8C%E6%9C%AA%E8%A2%AB%E5%88%AA%E9%99%A4%EF%BC%89%E3%80%82%E7%B5%90%E6%9E%9C%E5%87%BD%E5%BC%8F%E5%85%A7%E5%87%BA%E7%8F%BE%E5%85%A9%E5%80%8B%20%60%22%22%22%60%20%E7%B5%90%E5%B0%BE%EF%BC%9A%E7%AC%AC%E4%B8%80%E5%80%8B%E6%AD%A3%E7%A2%BA%E9%97%9C%E9%96%89%20docstring%EF%BC%8C%E7%AC%AC%E4%BA%8C%E5%80%8B%E5%8D%BB%E5%9C%A8%E5%87%BD%E5%BC%8F%E9%AB%94%E5%85%A7%E9%96%8B%E5%95%9F%E4%B8%80%E5%80%8B%E6%96%B0%E7%9A%84%E4%B8%89%E5%BC%95%E8%99%9F%E5%AD%97%E4%B8%B2%E5%B8%B8%E9%87%8F%EF%BC%8C%E6%8A%8A%20%60if%20not%20pngBytes%3A%60%20%E4%BB%A5%E4%B8%8B%E7%9A%84%E6%89%80%E6%9C%89%E7%A8%8B%E5%BC%8F%E7%A2%BC%E9%83%BD%E5%8C%85%E9%80%B2%E5%AD%97%E4%B8%B2%E8%A3%A1%EF%BC%8C%E4%B8%A6%E4%B8%80%E8%B7%AF%E6%B6%88%E8%80%97%E5%88%B0%20%60_getDpiScale%60%20%E7%9A%84%20docstring%20%E9%96%8B%E9%A0%AD%E6%89%8D%E9%97%9C%E9%96%89%E3%80%82%E9%80%99%E7%9B%B4%E6%8E%A5%E5%B0%8E%E8%87%B4%20%60SyntaxError%3A%20unterminated%20string%20literal%60%E2%80%94%E2%80%94Python%20%E5%AF%A6%E9%9A%9B%E9%A9%97%E8%AD%89%EF%BC%88%60ast.parse%60%EF%BC%89%E5%B7%B2%E7%A2%BA%E8%AA%8D%E6%AD%A4%E9%8C%AF%E8%AA%A4%EF%BC%8C%E6%8F%92%E4%BB%B6%E6%95%B4%E9%AB%94%E7%84%A1%E6%B3%95%E8%BC%89%E5%85%A5%E3%80%82%0A%0A%60%60%60suggestion%0Adef%20_describeImageBytes%28pngBytes%2C%20timeout%3D30.0%29%3A%0A%09%22%22%22Send%20PNG%20image%20bytes%20to%20the%20active%20image-description%20provider%20and%20return%20%28description%2C%20error_msg%29.%0A%0A%09Returns%20%28text%2C%20None%29%20on%20success%20or%20%28None%2C%20error_msg%29%20on%20failure.%0A%09%22%22%22%0A%09if%20not%20pngBytes%3A%0A%09%09return%20None%2C%20_%28%22%E7%84%A1%E6%B3%95%E5%8F%96%E5%BE%97%E5%9C%96%E7%89%87%E8%B3%87%E6%96%99%22%29%0A%09contents%20%3D%20_buildInitialImageContents%28pngBytes%29%0A%09return%20_callImageDescriptionApi%28contents%2C%20timeout%3Dtimeout%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=keyang556%2Flinedesktopnvda&pr=65&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Ffervent-haibt-076fc8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Ffervent-haibt-076fc8%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%202651-2661%0A%0AComment%3A%0A**%E8%AA%9E%E6%B3%95%E9%8C%AF%E8%AA%A4%EF%BC%9ADocstring%20%E7%B5%90%E5%B0%BE%E9%87%8D%E8%A4%87%EF%BC%8C%E5%B0%8E%E8%87%B4%E6%8F%92%E4%BB%B6%E7%84%A1%E6%B3%95%E8%BC%89%E5%85%A5**%0A%0APR%20%E4%BD%9C%E8%80%85%E5%9C%A8%E6%9B%B4%E6%96%B0%20docstring%20%E9%A6%96%E8%A1%8C%E6%99%82%EF%BC%8C%E5%A4%9A%E6%8F%92%E5%85%A5%E4%BA%86%E4%B8%80%E7%B5%84%20%60Returns...%60%20%E8%88%87%20%60%22%22%22%60%20%E8%A1%8C%EF%BC%8C%E4%BD%86%E5%8E%9F%E6%9C%AC%E7%9A%84%E9%80%99%E5%85%A9%E8%A1%8C%E4%BB%8D%E4%BF%9D%E7%95%99%EF%BC%88%E5%B1%AC%20diff%20%E4%B8%AD%E7%9A%84%20context%20%E8%A1%8C%EF%BC%8C%E6%9C%AA%E8%A2%AB%E5%88%AA%E9%99%A4%EF%BC%89%E3%80%82%E7%B5%90%E6%9E%9C%E5%87%BD%E5%BC%8F%E5%85%A7%E5%87%BA%E7%8F%BE%E5%85%A9%E5%80%8B%20%60%22%22%22%60%20%E7%B5%90%E5%B0%BE%EF%BC%9A%E7%AC%AC%E4%B8%80%E5%80%8B%E6%AD%A3%E7%A2%BA%E9%97%9C%E9%96%89%20docstring%EF%BC%8C%E7%AC%AC%E4%BA%8C%E5%80%8B%E5%8D%BB%E5%9C%A8%E5%87%BD%E5%BC%8F%E9%AB%94%E5%85%A7%E9%96%8B%E5%95%9F%E4%B8%80%E5%80%8B%E6%96%B0%E7%9A%84%E4%B8%89%E5%BC%95%E8%99%9F%E5%AD%97%E4%B8%B2%E5%B8%B8%E9%87%8F%EF%BC%8C%E6%8A%8A%20%60if%20not%20pngBytes%3A%60%20%E4%BB%A5%E4%B8%8B%E7%9A%84%E6%89%80%E6%9C%89%E7%A8%8B%E5%BC%8F%E7%A2%BC%E9%83%BD%E5%8C%85%E9%80%B2%E5%AD%97%E4%B8%B2%E8%A3%A1%EF%BC%8C%E4%B8%A6%E4%B8%80%E8%B7%AF%E6%B6%88%E8%80%97%E5%88%B0%20%60_getDpiScale%60%20%E7%9A%84%20docstring%20%E9%96%8B%E9%A0%AD%E6%89%8D%E9%97%9C%E9%96%89%E3%80%82%E9%80%99%E7%9B%B4%E6%8E%A5%E5%B0%8E%E8%87%B4%20%60SyntaxError%3A%20unterminated%20string%20literal%60%E2%80%94%E2%80%94Python%20%E5%AF%A6%E9%9A%9B%E9%A9%97%E8%AD%89%EF%BC%88%60ast.parse%60%EF%BC%89%E5%B7%B2%E7%A2%BA%E8%AA%8D%E6%AD%A4%E9%8C%AF%E8%AA%A4%EF%BC%8C%E6%8F%92%E4%BB%B6%E6%95%B4%E9%AB%94%E7%84%A1%E6%B3%95%E8%BC%89%E5%85%A5%E3%80%82%0A%0A%60%60%60suggestion%0Adef%20_describeImageBytes%28pngBytes%2C%20timeout%3D30.0%29%3A%0A%09%22%22%22Send%20PNG%20image%20bytes%20to%20the%20active%20image-description%20provider%20and%20return%20%28description%2C%20error_msg%29.%0A%0A%09Returns%20%28text%2C%20None%29%20on%20success%20or%20%28None%2C%20error_msg%29%20on%20failure.%0A%09%22%22%22%0A%09if%20not%20pngBytes%3A%0A%09%09return%20None%2C%20_%28%22%E7%84%A1%E6%B3%95%E5%8F%96%E5%BE%97%E5%9C%96%E7%89%87%E8%B3%87%E6%96%99%22%29%0A%09contents%20%3D%20_buildInitialImageContents%28pngBytes%29%0A%09return%20_callImageDescriptionApi%28contents%2C%20timeout%3Dtimeout%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aaddon%2FappModules%2Fline.py%3A2574-2576%0A**%60elif%60%20%E5%8F%AF%E8%83%BD%E9%9D%9C%E9%BB%98%E4%B8%9F%E6%A3%84%E5%BD%B1%E5%83%8F%E8%B3%87%E6%96%99**%0A%0A%E7%9B%AE%E5%89%8D%E8%8B%A5%E6%9F%90%E5%80%8B%20part%20%E5%90%8C%E6%99%82%E5%90%AB%E6%9C%89%20%60%22text%22%60%EF%BC%88%E9%9D%9E%E7%A9%BA%E5%AD%97%E4%B8%B2%EF%BC%89%E8%88%87%20%60%22inline_data%22%60%20%E5%85%A9%E5%80%8B%20key%EF%BC%8C%60elif%60%20%E5%88%86%E6%94%AF%E6%9C%83%E7%95%A5%E9%81%8E%20%60inline_data%60%EF%BC%8C%E5%B0%8E%E8%87%B4%E5%BD%B1%E5%83%8F%E8%B3%87%E6%96%99%E7%84%A1%E8%81%B2%E6%B6%88%E5%A4%B1%E3%80%82%E9%9B%96%E7%84%B6%20Gemini%20API%20%E5%9B%9E%E5%82%B3%E7%9A%84%20part%20%E5%9C%A8%E5%AF%A6%E5%8B%99%E4%B8%8A%E4%B8%8D%E6%9C%83%E5%90%8C%E6%99%82%E5%B8%B6%E6%9C%89%E9%80%99%E5%85%A9%E5%80%8B%E6%AC%84%E4%BD%8D%EF%BC%8C%E4%BD%86%E6%94%B9%E7%94%A8%E5%85%A9%E5%80%8B%E7%8D%A8%E7%AB%8B%E7%9A%84%20%60if%60%20%E5%88%A4%E6%96%B7%EF%BC%8C%E8%AE%93%E6%96%87%E5%AD%97%E5%92%8C%E5%BD%B1%E5%83%8F%E5%90%84%E8%87%AA%E7%8D%A8%E7%AB%8B%E6%94%B6%E9%9B%86%EF%BC%8C%E9%98%B2%E7%A6%A6%E6%80%A7%E6%9B%B4%E5%BC%B7%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09%09if%20%22text%22%20in%20part%20and%20part%5B%22text%22%5D%3A%0A%09%09%09%09texts.append%28part%5B%22text%22%5D%29%0A%09%09%09if%20%22inline_data%22%20in%20part%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aaddon%2FappModules%2Fline.py%3A2256-2264%0A**%E5%85%81%E8%A8%B1%E6%B8%85%E5%96%AE%E9%A9%97%E8%AD%89%E5%8F%AF%E8%83%BD%E9%9D%9C%E9%BB%98%E4%B8%9F%E6%A3%84%E5%B7%B2%E5%84%B2%E5%AD%98%E7%9A%84%E8%87%AA%E8%A8%82%E6%A8%A1%E5%9E%8B**%0A%0A%60getUserOllamaModel%28%29%60%20%E5%9C%A8%E5%BE%9E%E7%A3%81%E7%A2%9F%E8%AE%80%E5%8F%96%E5%BE%8C%EF%BC%8C%E6%9C%83%E9%A9%97%E8%AD%89%E8%AE%80%E5%88%B0%E7%9A%84%E5%80%BC%E6%98%AF%E5%90%A6%E5%9C%A8%20%60_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS%60%20%E4%B8%AD%EF%BC%9B%E8%8B%A5%E4%B8%8D%E7%AC%A6%E5%90%88%E5%89%87%E5%82%B3%E5%9B%9E%20%60None%60%20%E4%B8%A6%E8%A8%98%E9%8C%84%E4%B8%80%E8%A1%8C%20debug%E3%80%82%E9%80%99%E8%A1%A8%E7%A4%BA%E8%8B%A5%E6%9C%AA%E4%BE%86%E6%9C%89%E7%89%88%E6%9C%AC%E6%9B%B4%E6%96%B0%E7%A7%BB%E9%99%A4%E4%BA%86%E6%9F%90%E5%80%8B%E6%A8%A1%E5%9E%8B%20ID%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E5%8E%9F%E6%9C%AC%E7%9A%84%E9%81%B8%E6%93%87%E6%9C%83%E5%9C%A8%E6%AF%AB%E7%84%A1%E9%80%9A%E7%9F%A5%E7%9A%84%E6%83%85%E6%B3%81%E4%B8%8B%E9%80%80%E5%9B%9E%E9%A0%90%E8%A8%AD%E5%80%BC%E3%80%82%E5%BB%BA%E8%AD%B0%E6%94%B9%E7%82%BA%20%60log.warning%60%20%E4%BB%A5%E6%8F%90%E9%AB%98%E5%8F%AF%E8%A6%8B%E5%BA%A6%EF%BC%8C%E8%AE%93%E4%BD%BF%E7%94%A8%E8%80%85%E6%9B%B4%E5%AE%B9%E6%98%93%E5%AF%9F%E8%A6%BA%E8%A8%AD%E5%AE%9A%E8%A2%AB%E9%87%8D%E7%BD%AE%E7%9A%84%E5%8E%9F%E5%9B%A0%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda&pr=65&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Ffervent-haibt-076fc8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Ffervent-haibt-076fc8%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aaddon%2FappModules%2Fline.py%3A2574-2576%0A**%60elif%60%20%E5%8F%AF%E8%83%BD%E9%9D%9C%E9%BB%98%E4%B8%9F%E6%A3%84%E5%BD%B1%E5%83%8F%E8%B3%87%E6%96%99**%0A%0A%E7%9B%AE%E5%89%8D%E8%8B%A5%E6%9F%90%E5%80%8B%20part%20%E5%90%8C%E6%99%82%E5%90%AB%E6%9C%89%20%60%22text%22%60%EF%BC%88%E9%9D%9E%E7%A9%BA%E5%AD%97%E4%B8%B2%EF%BC%89%E8%88%87%20%60%22inline_data%22%60%20%E5%85%A9%E5%80%8B%20key%EF%BC%8C%60elif%60%20%E5%88%86%E6%94%AF%E6%9C%83%E7%95%A5%E9%81%8E%20%60inline_data%60%EF%BC%8C%E5%B0%8E%E8%87%B4%E5%BD%B1%E5%83%8F%E8%B3%87%E6%96%99%E7%84%A1%E8%81%B2%E6%B6%88%E5%A4%B1%E3%80%82%E9%9B%96%E7%84%B6%20Gemini%20API%20%E5%9B%9E%E5%82%B3%E7%9A%84%20part%20%E5%9C%A8%E5%AF%A6%E5%8B%99%E4%B8%8A%E4%B8%8D%E6%9C%83%E5%90%8C%E6%99%82%E5%B8%B6%E6%9C%89%E9%80%99%E5%85%A9%E5%80%8B%E6%AC%84%E4%BD%8D%EF%BC%8C%E4%BD%86%E6%94%B9%E7%94%A8%E5%85%A9%E5%80%8B%E7%8D%A8%E7%AB%8B%E7%9A%84%20%60if%60%20%E5%88%A4%E6%96%B7%EF%BC%8C%E8%AE%93%E6%96%87%E5%AD%97%E5%92%8C%E5%BD%B1%E5%83%8F%E5%90%84%E8%87%AA%E7%8D%A8%E7%AB%8B%E6%94%B6%E9%9B%86%EF%BC%8C%E9%98%B2%E7%A6%A6%E6%80%A7%E6%9B%B4%E5%BC%B7%E3%80%82%0A%0A%60%60%60suggestion%0A%09%09%09if%20%22text%22%20in%20part%20and%20part%5B%22text%22%5D%3A%0A%09%09%09%09texts.append%28part%5B%22text%22%5D%29%0A%09%09%09if%20%22inline_data%22%20in%20part%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aaddon%2FappModules%2Fline.py%3A2256-2264%0A**%E5%85%81%E8%A8%B1%E6%B8%85%E5%96%AE%E9%A9%97%E8%AD%89%E5%8F%AF%E8%83%BD%E9%9D%9C%E9%BB%98%E4%B8%9F%E6%A3%84%E5%B7%B2%E5%84%B2%E5%AD%98%E7%9A%84%E8%87%AA%E8%A8%82%E6%A8%A1%E5%9E%8B**%0A%0A%60getUserOllamaModel%28%29%60%20%E5%9C%A8%E5%BE%9E%E7%A3%81%E7%A2%9F%E8%AE%80%E5%8F%96%E5%BE%8C%EF%BC%8C%E6%9C%83%E9%A9%97%E8%AD%89%E8%AE%80%E5%88%B0%E7%9A%84%E5%80%BC%E6%98%AF%E5%90%A6%E5%9C%A8%20%60_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS%60%20%E4%B8%AD%EF%BC%9B%E8%8B%A5%E4%B8%8D%E7%AC%A6%E5%90%88%E5%89%87%E5%82%B3%E5%9B%9E%20%60None%60%20%E4%B8%A6%E8%A8%98%E9%8C%84%E4%B8%80%E8%A1%8C%20debug%E3%80%82%E9%80%99%E8%A1%A8%E7%A4%BA%E8%8B%A5%E6%9C%AA%E4%BE%86%E6%9C%89%E7%89%88%E6%9C%AC%E6%9B%B4%E6%96%B0%E7%A7%BB%E9%99%A4%E4%BA%86%E6%9F%90%E5%80%8B%E6%A8%A1%E5%9E%8B%20ID%EF%BC%8C%E4%BD%BF%E7%94%A8%E8%80%85%E5%8E%9F%E6%9C%AC%E7%9A%84%E9%81%B8%E6%93%87%E6%9C%83%E5%9C%A8%E6%AF%AB%E7%84%A1%E9%80%9A%E7%9F%A5%E7%9A%84%E6%83%85%E6%B3%81%E4%B8%8B%E9%80%80%E5%9B%9E%E9%A0%90%E8%A8%AD%E5%80%BC%E3%80%82%E5%BB%BA%E8%AD%B0%E6%94%B9%E7%82%BA%20%60log.warning%60%20%E4%BB%A5%E6%8F%90%E9%AB%98%E5%8F%AF%E8%A6%8B%E5%BA%A6%EF%BC%8C%E8%AE%93%E4%BD%BF%E7%94%A8%E8%80%85%E6%9B%B4%E5%AE%B9%E6%98%93%E5%AF%9F%E8%A6%BA%E8%A8%AD%E5%AE%9A%E8%A2%AB%E9%87%8D%E7%BD%AE%E7%9A%84%E5%8E%9F%E5%9B%A0%E3%80%82%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 2574-2576

Comment:
**`elif` 可能靜默丟棄影像資料**

目前若某個 part 同時含有 `"text"`（非空字串）與 `"inline_data"` 兩個 key，`elif` 分支會略過 `inline_data`，導致影像資料無聲消失。雖然 Gemini API 回傳的 part 在實務上不會同時帶有這兩個欄位，但改用兩個獨立的 `if` 判斷，讓文字和影像各自獨立收集，防禦性更強。

```suggestion
			if "text" in part and part["text"]:
				texts.append(part["text"])
			if "inline_data" in part:
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: addon/appModules/line.py
Line: 2256-2264

Comment:
**允許清單驗證可能靜默丟棄已儲存的自訂模型**

`getUserOllamaModel()` 在從磁碟讀取後，會驗證讀到的值是否在 `_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS` 中；若不符合則傳回 `None` 並記錄一行 debug。這表示若未來有版本更新移除了某個模型 ID，使用者原本的選擇會在毫無通知的情況下退回預設值。建議改為 `log.warning` 以提高可見度，讓使用者更容易察覺設定被重置的原因。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Add Ollama Cloud support to image descri..."](https://github.com/keyang556/linedesktopnvda/commit/11fd9ac1d51eea44da02b04100cb206d5c150896) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29704900)</sub>

<!-- /greptile_comment -->