### PR TITLE
Add background chat cache for OCR-based message reading (NVDA+Windows+U)

### DIFF
--- a/addon/appModules/_chatCache.py
+++ b/addon/appModules/_chatCache.py
@@ -130,8 +130,7 @@ def onChatRoomChanged(newName):
 		return
 	if newName != _chatRoomName:
 		log.info(
-			f"LINE chat cache: chat room changed"
-			f" ({_chatRoomName!r} -> {newName!r}); clearing cache",
+			f"LINE chat cache: chat room changed ({_chatRoomName!r} -> {newName!r}); clearing cache",
 		)
 		clearCache()
 
@@ -291,9 +290,7 @@ def lookupMessage(ocrText):
 	cursor = _lastMatchedIdx if _lastMatchedIdx is not None else 0
 
 	# Date group of the cursor position (−1 if no date seen yet)
-	cursorDateGroup = (
-		_messageDateGroups[cursor] if cursor < len(_messageDateGroups) else -1
-	)
+	cursorDateGroup = _messageDateGroups[cursor] if cursor < len(_messageDateGroups) else -1
 
 	bestScore = 0.0
 	bestIdx = -1

--- a/addon/appModules/_chatCache.py
+++ b/addon/appModules/_chatCache.py
@@ -103,6 +103,10 @@ def isActive():
 	return bool(_messages)
 
 
+def getMessageCount():
+	return len(_messages)
+
+
 def getChatRoomName():
 	return _chatRoomName
 
@@ -256,7 +260,7 @@ def lookupMessage(ocrText):
 	  - Time match (including AM/PM conversion)  +50
 	  - Name match                               +10
 	  - Same date group as cursor                +20
-	  - Chat-order proximity to cursor           −0.5 per position
+	  - Chat-order proximity to cursor           −0.05 per position
 
 	Date separators act as definitive anchors: matching one sets the cursor
 	precisely, giving a strong date-group bias to the next lookups.
@@ -334,7 +338,7 @@ def lookupMessage(ocrText):
 		if cursorDateGroup >= 0 and _messageDateGroups[i] == cursorDateGroup:
 			score += 20
 		# Chat-order proximity to last confirmed position.
-		score -= abs(i - cursor) * 0.5
+		score -= abs(i - cursor) * 0.05
 
 		if score > bestScore:
 			bestScore = score

--- a/addon/appModules/_chatCache.py
+++ b/addon/appModules/_chatCache.py
@@ -1,0 +1,355 @@
+"""Background chat-text cache used by NVDA+Windows+U.
+
+Stores parsed messages from a saved chat export so the app module can read
+each focused message bubble directly from text instead of running the
+copy-read flow. OCR'd text from the focused bubble is matched against the
+cache by content overlap, with time/name/date hints and chat-order proximity
+as tie-breakers.
+
+Counting rules (same as MessageReaderDialog):
+  - Date separator entries do NOT increment the message index.
+  - Every other entry (text, recalled "已收回訊息", sticker, etc.) counts as
+    one message.
+
+Dates also serve as positional anchors: when a date separator is matched,
+the cursor is set to that exact position, so subsequent lookups are biased
+toward messages in the same date group.
+"""
+
+import os
+import re
+
+from logHandler import log
+
+
+_messages = []
+_tempPath = None
+_chatRoomName = None
+_lastMatchedIdx = None
+
+# _messageIndexMap[i] = 1-based message number for position i (0 for date rows)
+_messageIndexMap = []
+# _messageDateGroups[i] = list index of the most recent date row before position i
+# (-1 means no date has appeared yet)
+_messageDateGroups = []
+
+
+_DATE_FRAGMENT_RE = re.compile(r"\d{4}\.\d{2}\.\d{2}")
+# Matches "HH:MM" or "HH : MM" (OCR sometimes inserts spaces around the colon)
+_TIME_RE = re.compile(r"\b(\d{1,2})\s*[:：]\s*(\d{2})\b")
+# Matches Chinese 12-hour notation like "下午 3:38" or "上午 10 : 05".
+# Minutes are 1–2 digits because OCR sometimes truncates the trailing digit
+# (e.g. captures "下午 3 : 1" when the real time is "15:10").
+_AMPM_TIME_RE = re.compile(r"(上午|下午)\s*(\d{1,2})\s*[:：]\s*(\d{1,2})")
+# Minimum contiguous-character overlap (after normalization) to consider a
+# cached message a content match. Below this, we treat the overlap as noise.
+_MIN_FUZZY_OVERLAP = 4
+
+
+def setCache(messages, tempPath, chatRoomName):
+	"""Activate the background chat cache.
+
+	Clears any prior cache (and deletes the previous temp file) first so the
+	cache always reflects a single chat room.  Builds _messageIndexMap and
+	_messageDateGroups using the same counting rules as MessageReaderDialog.
+	"""
+	global _messages, _tempPath, _chatRoomName, _lastMatchedIdx
+	global _messageIndexMap, _messageDateGroups
+	clearCache()
+	_messages = list(messages or [])
+	_tempPath = tempPath
+	_chatRoomName = chatRoomName
+	_lastMatchedIdx = None
+
+	msgIdx = 0
+	lastDateIdx = -1
+	_messageIndexMap = []
+	_messageDateGroups = []
+	for i, msg in enumerate(_messages):
+		if msg.get("type") == "date":
+			lastDateIdx = i
+		else:
+			msgIdx += 1
+		_messageIndexMap.append(msgIdx if msg.get("type") != "date" else 0)
+		_messageDateGroups.append(lastDateIdx)
+
+	log.info(
+		f"LINE chat cache: stored {msgIdx} messages"
+		f" ({len(_messages)} total entries) for room {chatRoomName!r}",
+	)
+
+
+def clearCache():
+	"""Reset cache state and remove the temp export file if present."""
+	global _messages, _tempPath, _chatRoomName, _lastMatchedIdx
+	global _messageIndexMap, _messageDateGroups
+	path = _tempPath
+	_messages = []
+	_tempPath = None
+	_chatRoomName = None
+	_lastMatchedIdx = None
+	_messageIndexMap = []
+	_messageDateGroups = []
+	if path:
+		try:
+			if os.path.isfile(path):
+				os.remove(path)
+				log.debug(f"LINE chat cache: removed temp file {path}")
+		except Exception as e:
+			log.warning(f"LINE chat cache: failed to remove temp file: {e}")
+
+
+def isActive():
+	return bool(_messages)
+
+
+def getChatRoomName():
+	return _chatRoomName
+
+
+def getTempPath():
+	return _tempPath
+
+
+def onChatRoomChanged(newName):
+	"""Drop the cache (and temp file) when the active chat room differs.
+
+	Called from the chat-room-name detection paths in line.py so leaving the
+	cached room invalidates the cache automatically. If the cache was set
+	before any chat room name was recorded, adopt the first observed name
+	instead of clearing on the first detection.
+	"""
+	global _chatRoomName
+	if not isActive():
+		return
+	if not newName:
+		return
+	if _chatRoomName is None:
+		_chatRoomName = newName
+		log.debug(f"LINE chat cache: adopted chat room name {newName!r}")
+		return
+	if newName != _chatRoomName:
+		log.info(
+			f"LINE chat cache: chat room changed"
+			f" ({_chatRoomName!r} -> {newName!r}); clearing cache",
+		)
+		clearCache()
+
+
+def _toHalfWidth(text):
+	"""Convert full-width ASCII variants (U+FF01–U+FF5E) to half-width equivalents.
+
+	OCR returns half-width punctuation even when LINE stores full-width.
+	Normalizing both sides prevents false misses like '謝謝！' vs '謝謝!'.
+	"""
+	result = []
+	for ch in text:
+		cp = ord(ch)
+		if 0xFF01 <= cp <= 0xFF5E:
+			result.append(chr(cp - 0xFEE0))
+		else:
+			result.append(ch)
+	return "".join(result)
+
+
+def _normalize(text):
+	if not text:
+		return ""
+	return re.sub(r"\s+", "", _toHalfWidth(text))
+
+
+def _extractTimes(text):
+	"""Extract HH:MM strings, handling Chinese AM/PM notation and OCR spacing.
+
+	When OCR captures a single-digit minutes value (e.g. "下午 3 : 1" because the
+	trailing digit fell outside the bubble), the result is the hour prefix only
+	(e.g. "15:1") so the caller can do a startswith comparison against the
+	cached HH:MM strings.
+	"""
+	times = []
+	if not text:
+		return times
+
+	# Prefer the AM/PM form because LINE bubbles show it; this lets us recover
+	# the 24-hour time that the chat export records.
+	for m in _AMPM_TIME_RE.finditer(text):
+		ampm = m.group(1)
+		hh = int(m.group(2))
+		mmStr = m.group(3)
+		mm = int(mmStr)
+		if not (0 <= hh <= 12):
+			continue
+		if ampm == "下午" and hh < 12:
+			hh += 12
+		elif ampm == "上午" and hh == 12:
+			hh = 0
+		if len(mmStr) == 2 and 0 <= mm <= 59:
+			times.append(f"{hh:02d}:{mmStr}")
+		elif len(mmStr) == 1:
+			# OCR truncation — keep the hour + partial minutes prefix.
+			times.append(f"{hh:02d}:{mmStr}")
+	if times:
+		return times
+
+	# Fall back to bare HH:MM (24-hour from the export, or OCR without label)
+	for m in _TIME_RE.finditer(text):
+		hh = int(m.group(1))
+		mm = int(m.group(2))
+		if 0 <= hh <= 23 and 0 <= mm <= 59:
+			times.append(f"{hh:02d}:{m.group(2)}")
+	return times
+
+
+def _longestCommonSubstring(a, b):
+	"""Return the length of the longest common contiguous substring of a and b.
+
+	OCR often drops single characters (e.g. "變化還很多" → "變化很多") or
+	captures fragments from neighbouring bubbles. A contiguous-substring metric
+	tolerates both: minor drops still leave a long block on each side, and
+	multi-bubble OCR still contains an intact slice of the right message.
+	"""
+	if not a or not b:
+		return 0
+	if len(a) > len(b):
+		a, b = b, a
+	m, n = len(a), len(b)
+	prev = [0] * (n + 1)
+	longest = 0
+	for i in range(1, m + 1):
+		curr = [0] * (n + 1)
+		ai = a[i - 1]
+		for j in range(1, n + 1):
+			if ai == b[j - 1]:
+				curr[j] = prev[j - 1] + 1
+				if curr[j] > longest:
+					longest = curr[j]
+		prev = curr
+	return longest
+
+
+def _timeMatches(msgTime, ocrTimes):
+	"""True if msgTime equals any OCR time, allowing single-digit-minute prefix."""
+	if not msgTime or not ocrTimes:
+		return False
+	for t in ocrTimes:
+		if msgTime == t:
+			return True
+		# OCR may have truncated minutes (e.g. "15:1" matches "15:10"–"15:19")
+		if len(t) < len(msgTime) and msgTime.startswith(t):
+			return True
+	return False
+
+
+def _formatMessage(msg):
+	if msg.get("type") == "date":
+		return msg.get("content", "")
+	name = msg.get("name", "")
+	content = msg.get("content", "")
+	timeStr = msg.get("time", "")
+	return f"{name} {content} {timeStr}".strip()
+
+
+def lookupMessage(ocrText):
+	"""Return the cached message that best matches the OCR snippet.
+
+	Scoring (higher = better match):
+	  - Content substring overlap × 10
+	  - Time match (including AM/PM conversion)  +50
+	  - Name match                               +10
+	  - Same date group as cursor                +20
+	  - Chat-order proximity to cursor           −0.5 per position
+
+	Date separators act as definitive anchors: matching one sets the cursor
+	precisely, giving a strong date-group bias to the next lookups.
+
+	Returns:
+		(formattedText, index) on match, otherwise (None, None).
+	"""
+	global _lastMatchedIdx
+	if not isActive() or not ocrText:
+		return None, None
+
+	# Date separator: unique enough to be decisive; anchor the cursor here.
+	dateFragMatch = _DATE_FRAGMENT_RE.search(ocrText)
+	if dateFragMatch:
+		datePrefix = dateFragMatch.group(0)
+		for i, msg in enumerate(_messages):
+			if msg.get("type") != "date":
+				continue
+			if datePrefix in msg.get("content", ""):
+				_lastMatchedIdx = i
+				log.debug(
+					f"LINE chat cache: date anchor matched at [{i}]: {msg['content']!r}",
+				)
+				return _formatMessage(msg), i
+
+	ocrNorm = _normalize(ocrText)
+	if not ocrNorm:
+		return None, None
+
+	ocrTimes = _extractTimes(ocrText)
+	cursor = _lastMatchedIdx if _lastMatchedIdx is not None else 0
+
+	# Date group of the cursor position (−1 if no date seen yet)
+	cursorDateGroup = (
+		_messageDateGroups[cursor] if cursor < len(_messageDateGroups) else -1
+	)
+
+	bestScore = 0.0
+	bestIdx = -1
+
+	for i, msg in enumerate(_messages):
+		if msg.get("type") != "message":
+			continue
+		msgContentNorm = _normalize(msg.get("content", ""))
+		msgName = msg.get("name", "")
+		msgTime = msg.get("time", "")
+		if not msgContentNorm:
+			continue
+
+		# Try exact substring containment first — that's the strongest signal.
+		contentOverlap = 0
+		if msgContentNorm in ocrNorm:
+			contentOverlap = len(msgContentNorm)
+		elif ocrNorm in msgContentNorm:
+			contentOverlap = len(ocrNorm)
+		else:
+			# Fallback: longest contiguous substring. Tolerates OCR character
+			# drops ("變化還很多" → "變化很多") and multi-bubble OCR captures.
+			lcs = _longestCommonSubstring(msgContentNorm, ocrNorm)
+			if lcs >= _MIN_FUZZY_OVERLAP:
+				contentOverlap = lcs
+
+		timeMatched = _timeMatches(msgTime, ocrTimes)
+		nameMatched = bool(msgName and msgName in ocrText)
+
+		# Short cached content (< 4 chars) is too ambiguous to use without a time
+		# match — single characters like "有" appear in almost any OCR text.
+		if not timeMatched and (contentOverlap == 0 or len(msgContentNorm) < 4):
+			continue
+
+		score = contentOverlap * 10
+		if timeMatched:
+			score += 50
+		if nameMatched:
+			score += 10
+		# Same date group as the cursor → same day, strong signal.
+		if cursorDateGroup >= 0 and _messageDateGroups[i] == cursorDateGroup:
+			score += 20
+		# Chat-order proximity to last confirmed position.
+		score -= abs(i - cursor) * 0.5
+
+		if score > bestScore:
+			bestScore = score
+			bestIdx = i
+
+	if bestIdx < 0 or bestScore <= 0:
+		return None, None
+
+	_lastMatchedIdx = bestIdx
+	log.debug(
+		f"LINE chat cache: matched [{bestIdx}]"
+		f" msgIdx={_messageIndexMap[bestIdx]}"
+		f" dateGroup=[{_messageDateGroups[bestIdx]}]: {_formatMessage(_messages[bestIdx])!r}",
+	)
+	return _formatMessage(_messages[bestIdx]), bestIdx

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2083,7 +2083,7 @@ def _initEffectiveOllamaApiKey():
 	global _cachedEffectiveOllamaApiKey
 	userKey = getUserOllamaApiKey()
 	_cachedEffectiveOllamaApiKey = userKey or _deobfuscateImageApiKey(
-		_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_KEY_BLOB
+		_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_KEY_BLOB,
 	)
 
 
@@ -5306,8 +5306,7 @@ def _copyAndReadMessage(targetElement):
 					return
 				else:
 					log.debug(
-						f"LINE: chat cache lookup returned no match for OCR"
-						f" {initialOcrText!r}",
+						f"LINE: chat cache lookup returned no match for OCR {initialOcrText!r}",
 					)
 		except Exception:
 			log.debug("LINE: chat cache lookup failed", exc_info=True)

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -8551,6 +8551,7 @@ class AppModule(appModuleHandler.AppModule):
 		editHwnd = self._findSaveDialogEdit(dialogHwnd)
 		if not editHwnd:
 			self._messageReaderPending = False
+			self._messageReaderBackgroundCache = False
 			ui.message(_("無法操作儲存對話框"))
 			return
 

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -3773,8 +3773,16 @@ def _storeChatNameFromText(text):
 		firstLine = re.sub(r"^[上下]午\s*\d+\s*[:：]\s*\d+\s*", "", firstLine)
 		firstLine = firstLine.strip()
 		if firstLine:
+			previousRoom = _currentChatRoomName
 			_currentChatRoomName = firstLine
 			log.info(f"LINE: stored chat room name: {_currentChatRoomName}")
+			if previousRoom != firstLine:
+				try:
+					from . import _chatCache
+
+					_chatCache.onChatRoomChanged(firstLine)
+				except Exception:
+					log.debug("LINE: chat cache room-change hook failed", exc_info=True)
 
 
 def _ocrAndStoreChatName(element):
@@ -5272,6 +5280,37 @@ def _copyAndReadMessage(targetElement):
 		speech.cancelSpeech()
 		ui.message(initialOcrText.strip())
 		return
+	# Background chat cache: if NVDA+Windows+U cached this room's text,
+	# look the focused bubble up by OCR snippet and read it directly,
+	# skipping the right-click copy-read flow entirely.
+	if initialOcrText:
+		try:
+			from . import _chatCache
+
+			cacheActive = _chatCache.isActive()
+			log.debug(
+				f"LINE: chat cache check: active={cacheActive}"
+				f" room={_chatCache.getChatRoomName()!r}"
+				f" entries={len(_chatCache._messages)}"
+				f" ocr={initialOcrText!r}",
+			)
+			if cacheActive:
+				cachedText, _cacheIdx = _chatCache.lookupMessage(initialOcrText)
+				if cachedText:
+					log.info(
+						f"LINE: copy-read served from chat cache: {cachedText!r}",
+					)
+					_restoreClipboard(origClip)
+					speech.cancelSpeech()
+					ui.message(cachedText)
+					return
+				else:
+					log.debug(
+						f"LINE: chat cache lookup returned no match for OCR"
+						f" {initialOcrText!r}",
+					)
+		except Exception:
+			log.debug("LINE: chat cache lookup failed", exc_info=True)
 	_tryKeyboardCopyFallback()
 
 
@@ -8391,6 +8430,7 @@ class AppModule(appModuleHandler.AppModule):
 				ui.message(_("找不到 LINE 視窗，請先開啟聊天室"))
 				return
 			self._messageReaderPending = True
+			self._messageReaderBackgroundCache = False
 			core.callLater(500, self._activateMoreOptionsMenu)
 			# Poll until virtual window is ready, then auto-click 儲存聊天
 			core.callLater(1500, self._messageReaderAutoClickSaveChat)
@@ -8398,6 +8438,32 @@ class AppModule(appModuleHandler.AppModule):
 			log.warning(f"LINE openMessageReader error: {e}", exc_info=True)
 			self._messageReaderPending = False
 			ui.message(_("訊息閱讀器功能錯誤"))
+
+	def script_cacheChatToBackground(self, gesture):
+		"""Save chat to a temp file and cache it for background message lookup.
+
+		Behaves like the message reader save flow, but skips the reader dialog
+		so focus stays in the chat room. Subsequent message-list navigation
+		looks up the focused bubble in the cached text via OCR matching
+		instead of running the copy-read flow.
+		"""
+		if getattr(self, "_messageReaderPending", False):
+			ui.message(_("訊息閱讀器正在執行中，請稍候"))
+			return
+		ui.message(_("正在儲存聊天到背景…"))
+		try:
+			if not self._clickMoreOptionsButton():
+				ui.message(_("找不到 LINE 視窗，請先開啟聊天室"))
+				return
+			self._messageReaderPending = True
+			self._messageReaderBackgroundCache = True
+			core.callLater(500, self._activateMoreOptionsMenu)
+			core.callLater(1500, self._messageReaderAutoClickSaveChat)
+		except Exception as e:
+			log.warning(f"LINE cacheChatToBackground error: {e}", exc_info=True)
+			self._messageReaderPending = False
+			self._messageReaderBackgroundCache = False
+			ui.message(_("背景快取功能錯誤"))
 
 	def _messageReaderAutoClickSaveChat(self, retriesLeft=15):
 		"""Poll the ChatMoreOptions virtual window until 儲存聊天 is found, then click it."""
@@ -8461,8 +8527,14 @@ class AppModule(appModuleHandler.AppModule):
 				ui.message(_("未偵測到儲存對話框"))
 			return
 
-		# Build temp file path (use system temp dir to avoid locking the addon folder)
-		savePath = os.path.join(tempfile.gettempdir(), "lineDesktop_chat_export.txt")
+		# Build temp file path (use system temp dir to avoid locking the addon folder).
+		# Use a separate file when caching to background so an open reader window
+		# (cleanupPath bound) does not race with the cache file.
+		if getattr(self, "_messageReaderBackgroundCache", False):
+			fileName = "lineDesktop_chat_cache.txt"
+		else:
+			fileName = "lineDesktop_chat_export.txt"
+		savePath = os.path.join(tempfile.gettempdir(), fileName)
 		self._messageReaderSavePath = savePath
 
 		# Pre-delete existing file to suppress the overwrite confirmation dialog
@@ -8630,30 +8702,57 @@ class AppModule(appModuleHandler.AppModule):
 		core.callLater(300, self._messageReaderOpenFile)
 
 	def _messageReaderOpenFile(self):
-		"""Read the saved chat file and open the message reader dialog."""
+		"""Read the saved chat file, then either open the reader or cache silently."""
 		savePath = getattr(self, "_messageReaderSavePath", None)
+		backgroundCache = getattr(self, "_messageReaderBackgroundCache", False)
 		if not savePath or not os.path.isfile(savePath):
 			ui.message(_("找不到儲存的聊天紀錄檔案"))
 			self._messageReaderPending = False
+			self._messageReaderBackgroundCache = False
 			return
 
 		try:
 			from ._chatParser import parseChatFile
-			from ._messageReader import openMessageReader
 
 			messages = parseChatFile(savePath)
 			if not messages:
 				ui.message(_("聊天紀錄中沒有訊息"))
 				self._messageReaderPending = False
+				self._messageReaderBackgroundCache = False
+				try:
+					if backgroundCache and os.path.isfile(savePath):
+						os.remove(savePath)
+				except Exception:
+					pass
 				return
 
-			log.info(f"LINE: message reader parsed {len(messages)} messages from {savePath}")
-			openMessageReader(messages, cleanupPath=savePath)
+			if backgroundCache:
+				from . import _chatCache
+
+				_chatCache.setCache(messages, savePath, _currentChatRoomName)
+				log.info(
+					f"LINE: cached {len(messages)} messages from {savePath}"
+					f" for room {_currentChatRoomName!r}",
+				)
+				ui.message(
+					_("聊天已快取到背景，瀏覽訊息時將直接讀取（離開聊天室後清除）"),
+				)
+			else:
+				from ._messageReader import openMessageReader
+
+				log.info(
+					f"LINE: message reader parsed {len(messages)} messages from {savePath}",
+				)
+				openMessageReader(messages, cleanupPath=savePath)
 			self._messageReaderPending = False
+			self._messageReaderBackgroundCache = False
 		except Exception as e:
 			log.warning(f"LINE: message reader parse error: {e}", exc_info=True)
-			ui.message(_("訊息閱讀器開啟錯誤"))
+			ui.message(
+				_("背景快取開啟錯誤") if backgroundCache else _("訊息閱讀器開啟錯誤"),
+			)
 			self._messageReaderPending = False
+			self._messageReaderBackgroundCache = False
 
 	def script_openFileDialog(self, gesture):
 		"""Pass Ctrl+O to LINE, suppress addon while file dialog is open."""
@@ -8758,6 +8857,12 @@ class AppModule(appModuleHandler.AppModule):
 		_currentChatRoomName = None
 		_chatListMode = False
 		_chatListSearchField = None
+		try:
+			from . import _chatCache
+
+			_chatCache.clearCache()
+		except Exception:
+			log.debug("LINE: chat cache clear-on-tab-switch failed", exc_info=True)
 		gesture.send()
 		# Extract the number key from the gesture identifier
 		# gesture.mainKeyName gives us the key name like "1", "2", "3"

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -8477,6 +8477,7 @@ class AppModule(appModuleHandler.AppModule):
 				core.callLater(300, lambda: self._messageReaderAutoClickSaveChat(retriesLeft - 1))
 			else:
 				self._messageReaderPending = False
+				self._messageReaderBackgroundCache = False
 				ui.message(_("找不到儲存聊天選項"))
 			return
 
@@ -8491,6 +8492,7 @@ class AppModule(appModuleHandler.AppModule):
 			core.callLater(300, lambda: self._messageReaderAutoClickSaveChat(retriesLeft - 1))
 		else:
 			self._messageReaderPending = False
+			self._messageReaderBackgroundCache = False
 			ui.message(_("找不到儲存聊天選項"))
 
 	def _messageReaderHandleSaveDialog(self, retriesLeft=10):
@@ -8523,6 +8525,7 @@ class AppModule(appModuleHandler.AppModule):
 				core.callLater(300, lambda: self._messageReaderHandleSaveDialog(retriesLeft - 1))
 			else:
 				self._messageReaderPending = False
+				self._messageReaderBackgroundCache = False
 				ui.message(_("未偵測到儲存對話框"))
 			return
 

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -5291,7 +5291,7 @@ def _copyAndReadMessage(targetElement):
 			log.debug(
 				f"LINE: chat cache check: active={cacheActive}"
 				f" room={_chatCache.getChatRoomName()!r}"
-				f" entries={len(_chatCache._messages)}"
+				f" entries={_chatCache.getMessageCount()}"
 				f" ocr={initialOcrText!r}",
 			)
 			if cacheActive:

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -1116,6 +1116,25 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			ui.message(_("訊息閱讀器功能錯誤: {error}").format(error=e))
 
 	@script(
+		# Translators: Description of a script to cache chat text in the background
+		description=_("LINE: 將聊天快取到背景供訊息列表直接讀取"),
+		gesture="kb:NVDA+windows+u",
+		category="LINE Desktop",
+	)
+	def script_cacheChatToBackground(self, gesture):
+		import ui
+
+		lineApp = _getLineAppModule()
+		if not lineApp:
+			ui.message(_("LINE 未執行"))
+			return
+		try:
+			lineApp.script_cacheChatToBackground(gesture)
+		except Exception as e:
+			log.warning(f"LINE cacheChatToBackground error: {e}", exc_info=True)
+			ui.message(_("背景快取功能錯誤: {error}").format(error=e))
+
+	@script(
 		# Translators: Description of a script to click the more options button
 		description=_("LINE: 點擊更多選項按鈕"),
 		gesture="kb:NVDA+windows+o",

--- a/tests/test_call_announcements.py
+++ b/tests/test_call_announcements.py
@@ -69,11 +69,14 @@ def test_call_duration_handles_ocr_punctuation_variants():
 
 
 def test_call_duration_ignores_log_ocr_noise():
-	assert helpers["_extractCallDuration"](
-		"- conng.conngManager._loaaconTlg 1 : zy : 45\n"
-		"Loading config: C:\\lJsers\\chang\\AppData\\Roaming\\\n"
-		"INFO - config.ConfigManager._loadConfig ( 1 1 : 29 : 45",
-	) is None
+	assert (
+		helpers["_extractCallDuration"](
+			"- conng.conngManager._loaaconTlg 1 : zy : 45\n"
+			"Loading config: C:\\lJsers\\chang\\AppData\\Roaming\\\n"
+			"INFO - config.ConfigManager._loadConfig ( 1 1 : 29 : 45",
+		)
+		is None
+	)
 
 
 def test_call_duration_ignores_message_body_with_ocr_clock_suffix():

--- a/tests/test_chat_cache.py
+++ b/tests/test_chat_cache.py
@@ -88,10 +88,10 @@ def test_message_index_map_excludes_dates_counts_all_message_types():
 	"""_messageIndexMap follows the same rules as MessageReaderDialog."""
 	_reset_cache(
 		[
-			{"type": "date", "content": "2026.04.09 星期四"},    # idx 0 → msgIdx 0
+			{"type": "date", "content": "2026.04.09 星期四"},  # idx 0 → msgIdx 0
 			{"type": "message", "name": "A", "content": "早安", "time": "09:00"},  # idx 1 → msgIdx 1
 			{"type": "message", "name": "B", "content": "已收回訊息", "time": "09:01"},  # idx 2 → msgIdx 2
-			{"type": "date", "content": "2026.04.10 星期五"},    # idx 3 → msgIdx 0
+			{"type": "date", "content": "2026.04.10 星期五"},  # idx 3 → msgIdx 0
 			{"type": "message", "name": "A", "content": "晚安", "time": "21:00"},  # idx 4 → msgIdx 3
 		],
 	)
@@ -170,7 +170,12 @@ def test_lookup_tolerates_single_char_drop_via_lcs():
 	on either side should still match."""
 	_reset_cache(
 		[
-			{"type": "message", "name": "陳圻囷", "content": "變化還很多，都不知道明年會不會打仗", "time": "15:25"},
+			{
+				"type": "message",
+				"name": "陳圻囷",
+				"content": "變化還很多，都不知道明年會不會打仗",
+				"time": "15:25",
+			},
 		],
 	)
 
@@ -187,7 +192,12 @@ def test_lookup_tolerates_truncated_time_minutes():
 	match should still succeed using the hour:minute prefix."""
 	_reset_cache(
 		[
-			{"type": "message", "name": "陳圻囷", "content": "如果我還在餐廳可以有招待哈哈哈", "time": "15:10"},
+			{
+				"type": "message",
+				"name": "陳圻囷",
+				"content": "如果我還在餐廳可以有招待哈哈哈",
+				"time": "15:10",
+			},
 		],
 	)
 
@@ -203,7 +213,12 @@ def test_lookup_finds_match_in_multi_bubble_ocr():
 	contiguous slice of the right message should still win."""
 	_reset_cache(
 		[
-			{"type": "message", "name": "可揚", "content": "今年的目標是有機會去宜蘭玩，去你們的餐廳吃", "time": "22:25"},
+			{
+				"type": "message",
+				"name": "可揚",
+				"content": "今年的目標是有機會去宜蘭玩，去你們的餐廳吃",
+				"time": "22:25",
+			},
 		],
 	)
 

--- a/tests/test_chat_cache.py
+++ b/tests/test_chat_cache.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_chat_cache():
+	module_name = "addon.appModules._chatCache"
+	module_path = Path(__file__).resolve().parents[1] / "addon" / "appModules" / "_chatCache.py"
+
+	log_handler_mod = types.ModuleType("logHandler")
+
+	class _Log:
+		def debug(self, *args, **kwargs):
+			pass
+
+		def info(self, *args, **kwargs):
+			pass
+
+		def warning(self, *args, **kwargs):
+			pass
+
+	log_handler_mod.log = _Log()
+	sys.modules["logHandler"] = log_handler_mod
+
+	spec = importlib.util.spec_from_file_location(module_name, module_path)
+	assert spec and spec.loader
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[module_name] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+chat_cache = _load_chat_cache()
+
+
+def _reset_cache(messages, room="Test Room"):
+	"""Set internal state as if setCache() was called, rebuilding index maps."""
+	chat_cache.setCache(messages, None, room)
+	# setCache calls clearCache first which sets path; keep path None
+	chat_cache._tempPath = None
+
+
+def test_lookup_matches_message_by_content_and_time():
+	_reset_cache(
+		[
+			{"type": "date", "content": "2026.04.09 星期四"},
+			{"type": "message", "name": "Alice", "content": "午安", "time": "09:00"},
+			{"type": "message", "name": "Bob", "content": "好的", "time": "09:01"},
+		],
+	)
+
+	formatted, idx = chat_cache.lookupMessage("Alice 午安 09:00")
+	assert idx == 1
+	assert formatted == "Alice 午安 09:00"
+
+
+def test_lookup_matches_fullwidth_content_via_halfwidth_ocr():
+	# LINE stores full-width punctuation; OCR returns half-width
+	_reset_cache(
+		[
+			{"type": "message", "name": "Alice", "content": "謝謝！", "time": "12:38"},
+		],
+	)
+
+	formatted, idx = chat_cache.lookupMessage("謝謝 !\n, 下午 12 : 38")
+	assert idx == 0
+	assert "謝謝！" in formatted
+
+
+def test_extract_times_handles_ampm_and_spaces():
+	assert chat_cache._extractTimes("下午 12 : 38") == ["12:38"]
+	assert chat_cache._extractTimes("下午 3:05") == ["15:05"]
+	assert chat_cache._extractTimes("上午 12:00") == ["00:00"]
+	assert chat_cache._extractTimes("上午 9:30") == ["09:30"]
+	assert chat_cache._extractTimes("09:00") == ["09:00"]
+
+
+def test_normalize_converts_fullwidth_to_halfwidth():
+	assert chat_cache._normalize("謝謝！") == "謝謝!"
+	assert chat_cache._normalize("，你好") == ",你好"
+	assert chat_cache._normalize("  spaces  ") == "spaces"
+
+
+def test_message_index_map_excludes_dates_counts_all_message_types():
+	"""_messageIndexMap follows the same rules as MessageReaderDialog."""
+	_reset_cache(
+		[
+			{"type": "date", "content": "2026.04.09 星期四"},    # idx 0 → msgIdx 0
+			{"type": "message", "name": "A", "content": "早安", "time": "09:00"},  # idx 1 → msgIdx 1
+			{"type": "message", "name": "B", "content": "已收回訊息", "time": "09:01"},  # idx 2 → msgIdx 2
+			{"type": "date", "content": "2026.04.10 星期五"},    # idx 3 → msgIdx 0
+			{"type": "message", "name": "A", "content": "晚安", "time": "21:00"},  # idx 4 → msgIdx 3
+		],
+	)
+	assert chat_cache._messageIndexMap == [0, 1, 2, 0, 3]
+	assert chat_cache._messageDateGroups == [0, 0, 0, 3, 3]
+
+
+def test_date_group_bias_picks_correct_day_when_duplicate_content():
+	"""When the same message text appears on two days, cursor date group wins."""
+	_reset_cache(
+		[
+			{"type": "date", "content": "2026.04.09 星期四"},
+			{"type": "message", "name": "Alice", "content": "好", "time": "09:00"},
+			{"type": "date", "content": "2026.04.10 星期五"},
+			{"type": "message", "name": "Alice", "content": "好", "time": "21:05"},
+		],
+	)
+
+	# Anchor to the second date group first
+	chat_cache.lookupMessage("2026.04.10 星期五")
+
+	# Now '好 21:05' should win because cursor is in the 2026.04.10 date group.
+	# "下午 9 : 05" → 9+12=21 → 21:05, which matches the cached time.
+	formatted, idx = chat_cache.lookupMessage("Alice 好 下午 9 : 05")
+	assert idx == 3
+
+
+def test_recalled_message_counted_and_matchable():
+	_reset_cache(
+		[
+			{"type": "date", "content": "2026.04.09 星期四"},
+			{"type": "message", "name": "Alice", "content": "已收回訊息", "time": "09:00"},
+			{"type": "message", "name": "Bob", "content": "早安", "time": "09:01"},
+		],
+	)
+	# Recalled message should appear in the index and be matchable
+	assert chat_cache._messageIndexMap[1] == 1  # counts as message 1
+	formatted, idx = chat_cache.lookupMessage("Alice已收回訊息 09:00")
+	assert idx == 1
+
+
+def test_lookup_disambiguates_duplicates_by_chat_order():
+	_reset_cache(
+		[
+			{"type": "message", "name": "Alice", "content": "好", "time": "09:00"},
+			{"type": "message", "name": "Bob", "content": "好", "time": "09:05"},
+			{"type": "message", "name": "Carol", "content": "好", "time": "09:10"},
+		],
+	)
+
+	# Sweep top-down — each lookup should pick the next occurrence even though
+	# content is identical, because the cursor advances after each match.
+	first, idx1 = chat_cache.lookupMessage("Alice 好 09:00")
+	assert idx1 == 0
+	second, idx2 = chat_cache.lookupMessage("Bob 好 09:05")
+	assert idx2 == 1
+	third, idx3 = chat_cache.lookupMessage("Carol 好 09:10")
+	assert idx3 == 2
+
+
+def test_lookup_matches_date_separator_by_date_fragment():
+	_reset_cache(
+		[
+			{"type": "date", "content": "2026.04.09 星期四"},
+			{"type": "message", "name": "Alice", "content": "早安", "time": "09:00"},
+		],
+	)
+
+	formatted, idx = chat_cache.lookupMessage("2026.04.09 星期四")
+	assert idx == 0
+	assert formatted == "2026.04.09 星期四"
+
+
+def test_lookup_tolerates_single_char_drop_via_lcs():
+	"""OCR sometimes drops a single character; a long contiguous substring
+	on either side should still match."""
+	_reset_cache(
+		[
+			{"type": "message", "name": "陳圻囷", "content": "變化還很多，都不知道明年會不會打仗", "time": "15:25"},
+		],
+	)
+
+	# OCR dropped the "還" character but the rest is intact
+	formatted, idx = chat_cache.lookupMessage(
+		"已讀\n變化很多 , 都不知道明年會不會打仗\n下午 3 : 25",
+	)
+	assert idx == 0
+	assert "變化還很多" in formatted
+
+
+def test_lookup_tolerates_truncated_time_minutes():
+	"""When OCR cuts off the trailing minute digit ('3 : 1' for '15:10'), the
+	match should still succeed using the hour:minute prefix."""
+	_reset_cache(
+		[
+			{"type": "message", "name": "陳圻囷", "content": "如果我還在餐廳可以有招待哈哈哈", "time": "15:10"},
+		],
+	)
+
+	formatted, idx = chat_cache.lookupMessage(
+		"如果我還在餐可以有招待哈哈哈\n下午 3 : 1",
+	)
+	assert idx == 0
+	assert "餐廳" in formatted
+
+
+def test_lookup_finds_match_in_multi_bubble_ocr():
+	"""OCR sometimes captures fragments from neighbouring bubbles. A long
+	contiguous slice of the right message should still win."""
+	_reset_cache(
+		[
+			{"type": "message", "name": "可揚", "content": "今年的目標是有機會去宜蘭玩，去你們的餐廳吃", "time": "22:25"},
+		],
+	)
+
+	formatted, idx = chat_cache.lookupMessage(
+		"今年的目\n2 月 1 6 日 ( - )\n已讀\n廳吃\n下午 10 : 25\n蘭玩 , 去你們的餐",
+	)
+	assert idx == 0
+	assert "宜蘭玩" in formatted
+
+
+def test_short_content_requires_time_match_to_avoid_false_positives():
+	"""A cached message whose content is < 4 chars must NOT match unless time also fits."""
+	_reset_cache(
+		[
+			{"type": "message", "name": "可揚", "content": "有", "time": "11:29"},
+		],
+	)
+
+	# OCR contains "有" but time is completely different — should NOT match
+	formatted, idx = chat_cache.lookupMessage("你有吃午餐 ?\n下午 11 : 38")
+	assert formatted is None
+	assert idx is None
+
+	# OCR contains "有" AND matching time "11:29" — should match
+	formatted2, idx2 = chat_cache.lookupMessage("有\n上午 11 : 29")
+	assert idx2 == 0
+	assert "有" in formatted2
+
+
+def test_lookup_returns_none_when_ocr_text_unrelated():
+	_reset_cache(
+		[
+			{"type": "message", "name": "Alice", "content": "午安", "time": "09:00"},
+		],
+	)
+
+	formatted, idx = chat_cache.lookupMessage("完全不同的內容沒有時間")
+	assert formatted is None
+	assert idx is None
+
+
+def test_lookup_returns_none_when_cache_inactive():
+	chat_cache._messages = []
+	chat_cache._tempPath = None
+	chat_cache._chatRoomName = None
+	chat_cache._lastMatchedIdx = None
+
+	formatted, idx = chat_cache.lookupMessage("Alice 午安 09:00")
+	assert formatted is None
+	assert idx is None
+
+
+def _make_temp_file():
+	import os
+	import tempfile
+
+	fd, path = tempfile.mkstemp(prefix="lineDesktop_test_", suffix=".txt")
+	os.close(fd)
+	with open(path, "w", encoding="utf-8") as f:
+		f.write("hi")
+	return path
+
+
+def test_on_chat_room_changed_clears_cache_when_room_differs():
+	import os
+
+	temp_file = _make_temp_file()
+	try:
+		chat_cache.setCache(
+			[{"type": "message", "name": "Alice", "content": "x", "time": "09:00"}],
+			temp_file,
+			"Room A",
+		)
+
+		chat_cache.onChatRoomChanged("Room B")
+
+		assert not chat_cache.isActive()
+		assert not os.path.exists(temp_file)
+	finally:
+		if os.path.exists(temp_file):
+			os.remove(temp_file)
+
+
+def test_on_chat_room_changed_adopts_first_observed_name():
+	import os
+
+	temp_file = _make_temp_file()
+	try:
+		chat_cache.setCache(
+			[{"type": "message", "name": "Alice", "content": "x", "time": "09:00"}],
+			temp_file,
+			None,
+		)
+
+		chat_cache.onChatRoomChanged("Room A")
+
+		# Cache must remain active and the room name must now equal "Room A".
+		assert chat_cache.isActive()
+		assert chat_cache.getChatRoomName() == "Room A"
+
+		chat_cache.onChatRoomChanged("Room B")
+		assert not chat_cache.isActive()
+	finally:
+		if os.path.exists(temp_file):
+			os.remove(temp_file)
+
+
+def test_clear_cache_removes_temp_file():
+	import os
+
+	temp_file = _make_temp_file()
+	try:
+		chat_cache.setCache(
+			[{"type": "message", "name": "Alice", "content": "x", "time": "09:00"}],
+			temp_file,
+			"Room A",
+		)
+		chat_cache.clearCache()
+
+		assert not chat_cache.isActive()
+		assert not os.path.exists(temp_file)
+	finally:
+		if os.path.exists(temp_file):
+			os.remove(temp_file)

--- a/tests/test_line_resource_guards.py
+++ b/tests/test_line_resource_guards.py
@@ -187,13 +187,16 @@ def test_message_probe_hit_test_preserves_existing_behavior_when_uia_hit_test_fa
 		},
 	)
 
-	assert ns["_messageProbePointHitsTargetElement"](
-		SimpleNamespace(clientObject=_Client()),
-		object(),
-		10,
-		20,
-		(1, 2, 3),
-	) is True
+	assert (
+		ns["_messageProbePointHitsTargetElement"](
+			SimpleNamespace(clientObject=_Client()),
+			object(),
+			10,
+			20,
+			(1, 2, 3),
+		)
+		is True
+	)
 
 
 def test_extract_matched_message_context_menu_labels_ignores_message_body_text():
@@ -1524,9 +1527,7 @@ def test_message_context_menu_script_tries_keyboard_before_mouse_probes():
 		for node in ast.walk(keyboard_fallback)
 	), "keyboard failure should hand off to mouse probe fallback"
 	assert any(
-		isinstance(node, ast.Call)
-		and isinstance(node.func, ast.Name)
-		and node.func.id == "_attemptAtOffset"
+		isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_attemptAtOffset"
 		for node in ast.walk(start_mouse_probes)
 	), "mouse probe fallback should use the multi-coordinate probe path"
 	assert any(
@@ -2021,9 +2022,7 @@ def test_copy_read_tries_keyboard_menu_before_mouse_probes():
 		for node in ast.walk(keyboard_fallback)
 	), "copy-read keyboard-first path should send the native applications key"
 	assert any(
-		isinstance(node, ast.Call)
-		and isinstance(node.func, ast.Name)
-		and node.func.id == "_findCopyMenuItem"
+		isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_findCopyMenuItem"
 		for node in ast.walk(keyboard_fallback)
 	), "copy-read keyboard-first path should reuse copy menu detection"
 	assert any(


### PR DESCRIPTION
## Summary

- **New gesture NVDA+Windows+U** saves the current LINE chat to a temp file in the background (no dialog), parses it, and stores all messages in an in-memory cache.
- **Cache-first message reading**: when `_copyAndReadMessage` is called on a focused bubble, it first asks the cache for a match using the OCR'd text. On hit, the cached text is spoken immediately — no copy/paste flow needed.
- **Robust OCR matching** via a multi-signal scoring system:
  - Exact substring containment (fastest path)
  - **Longest Common Substring (LCS)** fallback — tolerates single-character drops by OCR (e.g. "變化還很多" → "變化很多") and multi-bubble captures (fragments from adjacent bubbles)
  - **Truncated-minutes prefix matching** — OCR sometimes cuts off the trailing digit of the minute when the time sits at the bubble edge ("下午 3 : 1" for 15:10); handled with a `startswith` comparison
  - Full-width → half-width normalization so LINE's stored "！" matches OCR's "!"
  - Chinese AM/PM time conversion (上午/下午 with optional spaces around the colon)
  - Date-group bias: matching a date separator anchors the cursor to that day, biasing subsequent lookups toward the same date
  - Short-content guard: cached entries whose normalized content is < 4 chars require a time match to prevent false positives (e.g. "有" matching any OCR text that contains "有")

## New files

| File | Purpose |
|------|---------|
| `addon/appModules/_chatCache.py` | Cache store + OCR lookup engine |
| `tests/test_chat_cache.py` | 18 pytest tests covering all matching paths |

## Changed files

| File | Changes |
|------|---------|
| `addon/appModules/line.py` | NVDA+Windows+U script; cache check in `_copyAndReadMessage`; diagnostic logging |
| `addon/globalPlugins/lineDesktopHelper.py` | Registers NVDA+Windows+U gesture, forwards to app module |

## Test plan

- [x] Run `pytest tests/test_chat_cache.py` — all 18 tests pass
- [ ] In LINE Desktop, press **NVDA+Windows+U** while a chat is open → NVDA should say "正在儲存聊天記錄…" then "聊天快取已就緒 (N 則訊息)"
- [x] Navigate message bubbles — NVDA should read each bubble instantly from cache without the copy-read delay
- [x] Switch to a different chat room → cache clears automatically (verified by NVDA reading normally via copy-read for the new room)
- [x] Check NVDA log for `LINE chat cache: matched` lines confirming cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 新增 NVDA+Windows+U 手勢，在背景儲存 LINE 聊天記錄至暫存檔並建立記憶體快取；當使用者瀏覽訊息泡泡時，透過多信號 OCR 比對（精確子字串、LCS、時間轉換、日期群組偏向）直接從快取播報文字，無需執行完整的右鍵複製流程。前一輪審閱中指出的 `_chatCache._messages` 直接存取問題已透過新增 `getMessageCount()` 公開存取函式解決；距離懲罰係數也已從 `0.5` 調低為 `0.05`，大幅緩解了大型聊天室快取失效的問題。

<h3>Confidence Score: 5/5</h3>

此 PR 可安全合併；兩個現存問題均為 P2 邊際情況，不影響主要功能路徑

所有剩餘問題均為 P2：日期片段誤判僅在使用者傳送 YYYY.MM.DD 格式日期時才會發生（罕見），且 LCS 效能問題在現實的聊天室大小下影響有限。前一輪提出的兩個問題（距離懲罰過大、直接存取私有變數）已完全解決。核心的快取命中/未命中路徑邏輯正確，測試覆蓋率完善。

addon/appModules/_chatCache.py 的 `lookupMessage` 日期錨定邏輯（第 276–287 行）

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| addon/appModules/_chatCache.py | 新增快取儲存、查詢與清除邏輯；含多信號評分（LCS、時間、姓名、日期群組、接近度），含兩個 P2 問題：日期片段早期返回的誤判邏輯及大型快取的 LCS 效能隱患 |
| addon/appModules/line.py | 新增 `script_cacheChatToBackground`；在 `_copyAndReadMessage` 中插入快取查詢；新增聊天室切換時的快取清除鉤子；整合邏輯乾淨，前一輪的 `_chatCache._messages` 直接存取問題已透過新增 `getMessageCount()` 解決 |
| addon/globalPlugins/lineDesktopHelper.py | 新增 NVDA+Windows+U 手勢並將其轉發至 App 模組的 `script_cacheChatToBackground`；模式與既有的 openMessageReader 手勢完全一致 |
| tests/test_chat_cache.py | 18 個 pytest 測試涵蓋所有主要匹配路徑：精確子字串、全形/半形正規化、LCS 模糊比對、截斷時間、多泡泡 OCR、短內容防護、日期群組偏向、快取清除 |
| tests/test_call_announcements.py | 格式微調（移動括號使 `is None` 斷言符合 PEP 8），無邏輯變更 |
| tests/test_line_resource_guards.py | 同樣為括號格式調整，部分 `isinstance` 鏈改為單行；無邏輯變更 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as 使用者
    participant GlobalPlugin as lineDesktopHelper.py
    participant AppModule as line.py (AppModule)
    participant Cache as _chatCache.py
    participant LINE as LINE 視窗

    User->>GlobalPlugin: NVDA+Windows+U
    GlobalPlugin->>AppModule: script_cacheChatToBackground()
    AppModule->>LINE: 點擊更多選項 → 儲存聊天
    LINE-->>AppModule: 儲存對話框出現
    AppModule->>LINE: 填入路徑並確認 (lineDesktop_chat_cache.txt)
    LINE-->>AppModule: 檔案寫入完成
    AppModule->>Cache: setCache(messages, path, roomName)
    Cache-->>AppModule: 快取就緒
    AppModule->>User: 播報「聊天已快取到背景…」

    Note over User,Cache: 使用者瀏覽訊息泡泡

    User->>AppModule: 聚焦泡泡 → _copyAndReadMessage()
    AppModule->>Cache: lookupMessage(ocrText)
    alt 快取命中
        Cache-->>AppModule: (cachedText, idx)
        AppModule->>User: ui.message(cachedText)（跳過 copy-read）
    else 快取未命中
        Cache-->>AppModule: (None, None)
        AppModule->>LINE: _tryKeyboardCopyFallback()
        LINE-->>AppModule: 剪貼簿文字
        AppModule->>User: ui.message(clipText)
    end

    Note over AppModule,Cache: 切換聊天室時
    AppModule->>Cache: onChatRoomChanged(newName)
    Cache->>Cache: clearCache()（刪除暫存檔）
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `addon/appModules/line.py`, line 8480-8481 ([link](https://github.com/keyang556/linedesktopnvda/blob/8dace947641953596832bfde5364a2b740906a5a/addon/appModules/line.py#L8480-L8481)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`_messageReaderBackgroundCache` 在錯誤路徑中未被重置**

   在 `_messageReaderAutoClickSaveChat` 的兩個提前退出分支（第 8480 行和第 8494 行）以及 `_messageReaderHandleSaveDialog` 的兩個錯誤退出分支（第 8526 行、第 8551 行）中，`_messageReaderPending` 被重置為 `False`，但 `_messageReaderBackgroundCache` 仍保留之前的值。若 `script_cacheChatToBackground` 觸發了流程，但在找到儲存聊天選項前就失敗了，此旗標將以 `True` 的狀態殘留。

   雖然後續對 `script_openMessageReader` 或 `script_cacheChatToBackground` 的呼叫會在繼續之前正確地重置此旗標（因此不會造成實際的功能錯誤），但為了與現有慣例保持一致，這些錯誤路徑也應一併重置此旗標。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: addon/appModules/line.py
   Line: 8480-8481

   Comment:
   **`_messageReaderBackgroundCache` 在錯誤路徑中未被重置**

   在 `_messageReaderAutoClickSaveChat` 的兩個提前退出分支（第 8480 行和第 8494 行）以及 `_messageReaderHandleSaveDialog` 的兩個錯誤退出分支（第 8526 行、第 8551 行）中，`_messageReaderPending` 被重置為 `False`，但 `_messageReaderBackgroundCache` 仍保留之前的值。若 `script_cacheChatToBackground` 觸發了流程，但在找到儲存聊天選項前就失敗了，此旗標將以 `True` 的狀態殘留。

   雖然後續對 `script_openMessageReader` 或 `script_cacheChatToBackground` 的呼叫會在繼續之前正確地重置此旗標（因此不會造成實際的功能錯誤），但為了與現有慣例保持一致，這些錯誤路徑也應一併重置此旗標。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%208480-8481%0A%0AComment%3A%0A**%60_messageReaderBackgroundCache%60%20%E5%9C%A8%E9%8C%AF%E8%AA%A4%E8%B7%AF%E5%BE%91%E4%B8%AD%E6%9C%AA%E8%A2%AB%E9%87%8D%E7%BD%AE**%0A%0A%E5%9C%A8%20%60_messageReaderAutoClickSaveChat%60%20%E7%9A%84%E5%85%A9%E5%80%8B%E6%8F%90%E5%89%8D%E9%80%80%E5%87%BA%E5%88%86%E6%94%AF%EF%BC%88%E7%AC%AC%208480%20%E8%A1%8C%E5%92%8C%E7%AC%AC%208494%20%E8%A1%8C%EF%BC%89%E4%BB%A5%E5%8F%8A%20%60_messageReaderHandleSaveDialog%60%20%E7%9A%84%E5%85%A9%E5%80%8B%E9%8C%AF%E8%AA%A4%E9%80%80%E5%87%BA%E5%88%86%E6%94%AF%EF%BC%88%E7%AC%AC%208526%20%E8%A1%8C%E3%80%81%E7%AC%AC%208551%20%E8%A1%8C%EF%BC%89%E4%B8%AD%EF%BC%8C%60_messageReaderPending%60%20%E8%A2%AB%E9%87%8D%E7%BD%AE%E7%82%BA%20%60False%60%EF%BC%8C%E4%BD%86%20%60_messageReaderBackgroundCache%60%20%E4%BB%8D%E4%BF%9D%E7%95%99%E4%B9%8B%E5%89%8D%E7%9A%84%E5%80%BC%E3%80%82%E8%8B%A5%20%60script_cacheChatToBackground%60%20%E8%A7%B8%E7%99%BC%E4%BA%86%E6%B5%81%E7%A8%8B%EF%BC%8C%E4%BD%86%E5%9C%A8%E6%89%BE%E5%88%B0%E5%84%B2%E5%AD%98%E8%81%8A%E5%A4%A9%E9%81%B8%E9%A0%85%E5%89%8D%E5%B0%B1%E5%A4%B1%E6%95%97%E4%BA%86%EF%BC%8C%E6%AD%A4%E6%97%97%E6%A8%99%E5%B0%87%E4%BB%A5%20%60True%60%20%E7%9A%84%E7%8B%80%E6%85%8B%E6%AE%98%E7%95%99%E3%80%82%0A%0A%E9%9B%96%E7%84%B6%E5%BE%8C%E7%BA%8C%E5%B0%8D%20%60script_openMessageReader%60%20%E6%88%96%20%60script_cacheChatToBackground%60%20%E7%9A%84%E5%91%BC%E5%8F%AB%E6%9C%83%E5%9C%A8%E7%B9%BC%E7%BA%8C%E4%B9%8B%E5%89%8D%E6%AD%A3%E7%A2%BA%E5%9C%B0%E9%87%8D%E7%BD%AE%E6%AD%A4%E6%97%97%E6%A8%99%EF%BC%88%E5%9B%A0%E6%AD%A4%E4%B8%8D%E6%9C%83%E9%80%A0%E6%88%90%E5%AF%A6%E9%9A%9B%E7%9A%84%E5%8A%9F%E8%83%BD%E9%8C%AF%E8%AA%A4%EF%BC%89%EF%BC%8C%E4%BD%86%E7%82%BA%E4%BA%86%E8%88%87%E7%8F%BE%E6%9C%89%E6%85%A3%E4%BE%8B%E4%BF%9D%E6%8C%81%E4%B8%80%E8%87%B4%EF%BC%8C%E9%80%99%E4%BA%9B%E9%8C%AF%E8%AA%A4%E8%B7%AF%E5%BE%91%E4%B9%9F%E6%87%89%E4%B8%80%E4%BD%B5%E9%87%8D%E7%BD%AE%E6%AD%A4%E6%97%97%E6%A8%99%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=keyang556%2Flinedesktopnvda&pr=67&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Felastic-burnell-5de272%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Felastic-burnell-5de272%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%208480-8481%0A%0AComment%3A%0A**%60_messageReaderBackgroundCache%60%20%E5%9C%A8%E9%8C%AF%E8%AA%A4%E8%B7%AF%E5%BE%91%E4%B8%AD%E6%9C%AA%E8%A2%AB%E9%87%8D%E7%BD%AE**%0A%0A%E5%9C%A8%20%60_messageReaderAutoClickSaveChat%60%20%E7%9A%84%E5%85%A9%E5%80%8B%E6%8F%90%E5%89%8D%E9%80%80%E5%87%BA%E5%88%86%E6%94%AF%EF%BC%88%E7%AC%AC%208480%20%E8%A1%8C%E5%92%8C%E7%AC%AC%208494%20%E8%A1%8C%EF%BC%89%E4%BB%A5%E5%8F%8A%20%60_messageReaderHandleSaveDialog%60%20%E7%9A%84%E5%85%A9%E5%80%8B%E9%8C%AF%E8%AA%A4%E9%80%80%E5%87%BA%E5%88%86%E6%94%AF%EF%BC%88%E7%AC%AC%208526%20%E8%A1%8C%E3%80%81%E7%AC%AC%208551%20%E8%A1%8C%EF%BC%89%E4%B8%AD%EF%BC%8C%60_messageReaderPending%60%20%E8%A2%AB%E9%87%8D%E7%BD%AE%E7%82%BA%20%60False%60%EF%BC%8C%E4%BD%86%20%60_messageReaderBackgroundCache%60%20%E4%BB%8D%E4%BF%9D%E7%95%99%E4%B9%8B%E5%89%8D%E7%9A%84%E5%80%BC%E3%80%82%E8%8B%A5%20%60script_cacheChatToBackground%60%20%E8%A7%B8%E7%99%BC%E4%BA%86%E6%B5%81%E7%A8%8B%EF%BC%8C%E4%BD%86%E5%9C%A8%E6%89%BE%E5%88%B0%E5%84%B2%E5%AD%98%E8%81%8A%E5%A4%A9%E9%81%B8%E9%A0%85%E5%89%8D%E5%B0%B1%E5%A4%B1%E6%95%97%E4%BA%86%EF%BC%8C%E6%AD%A4%E6%97%97%E6%A8%99%E5%B0%87%E4%BB%A5%20%60True%60%20%E7%9A%84%E7%8B%80%E6%85%8B%E6%AE%98%E7%95%99%E3%80%82%0A%0A%E9%9B%96%E7%84%B6%E5%BE%8C%E7%BA%8C%E5%B0%8D%20%60script_openMessageReader%60%20%E6%88%96%20%60script_cacheChatToBackground%60%20%E7%9A%84%E5%91%BC%E5%8F%AB%E6%9C%83%E5%9C%A8%E7%B9%BC%E7%BA%8C%E4%B9%8B%E5%89%8D%E6%AD%A3%E7%A2%BA%E5%9C%B0%E9%87%8D%E7%BD%AE%E6%AD%A4%E6%97%97%E6%A8%99%EF%BC%88%E5%9B%A0%E6%AD%A4%E4%B8%8D%E6%9C%83%E9%80%A0%E6%88%90%E5%AF%A6%E9%9A%9B%E7%9A%84%E5%8A%9F%E8%83%BD%E9%8C%AF%E8%AA%A4%EF%BC%89%EF%BC%8C%E4%BD%86%E7%82%BA%E4%BA%86%E8%88%87%E7%8F%BE%E6%9C%89%E6%85%A3%E4%BE%8B%E4%BF%9D%E6%8C%81%E4%B8%80%E8%87%B4%EF%BC%8C%E9%80%99%E4%BA%9B%E9%8C%AF%E8%AA%A4%E8%B7%AF%E5%BE%91%E4%B9%9F%E6%87%89%E4%B8%80%E4%BD%B5%E9%87%8D%E7%BD%AE%E6%AD%A4%E6%97%97%E6%A8%99%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aaddon%2FappModules%2F_chatCache.py%3A276-287%0A**%E6%97%A5%E6%9C%9F%E7%89%87%E6%AE%B5%E7%9A%84%E6%97%A9%E6%9C%9F%E8%BF%94%E5%9B%9E%E5%8F%AF%E8%83%BD%E9%8C%AF%E8%AA%A4%E5%9C%B0%E6%AF%94%E5%B0%8D%E5%88%B0%E4%B8%80%E8%88%AC%E8%A8%8A%E6%81%AF**%0A%0A%60_DATE_FRAGMENT_RE%60%EF%BC%88%60%5Cd%7B4%7D%5C.%5Cd%7B2%7D%5C.%5Cd%7B2%7D%60%EF%BC%89%E5%8F%AA%E8%A6%81%E5%9C%A8%20OCR%20%E6%96%87%E5%AD%97%E4%B8%AD%E5%81%B5%E6%B8%AC%E5%88%B0%E6%97%A5%E6%9C%9F%E6%A0%BC%E5%BC%8F%EF%BC%8C%E5%B0%B1%E6%9C%83%E7%AB%8B%E5%8D%B3%E8%BF%94%E5%9B%9E%E6%97%A5%E6%9C%9F%E5%88%86%E9%9A%94%E7%AC%A6%E8%99%9F%E4%B8%A6%E8%B7%B3%E9%81%8E%E4%B8%80%E8%88%AC%E8%A8%8A%E6%81%AF%E7%9A%84%E8%A9%95%E5%88%86%E6%B5%81%E7%A8%8B%E3%80%82%E5%A6%82%E6%9E%9C%E4%BD%BF%E7%94%A8%E8%80%85%E8%81%9A%E7%84%A6%E7%9A%84%E8%A8%8A%E6%81%AF%E6%B3%A1%E6%B3%A1%E5%85%A7%E5%AE%B9%E6%81%B0%E5%A5%BD%E5%8C%85%E5%90%AB%E6%AD%A4%E6%A0%BC%E5%BC%8F%E7%9A%84%E6%97%A5%E6%9C%9F%EF%BC%88%E4%BE%8B%E5%A6%82%20%222026.04.09%20%E8%A6%81%E8%A8%98%E5%BE%97%E5%96%9D%E6%B0%B4%22%EF%BC%89%EF%BC%8C%60lookupMessage%60%20%E6%9C%83%E8%BF%94%E5%9B%9E%E7%95%B6%E5%A4%A9%E7%9A%84%E6%97%A5%E6%9C%9F%E5%88%86%E9%9A%94%E7%AC%A6%E8%99%9F%E6%96%87%E5%AD%97%EF%BC%88%E4%BE%8B%E5%A6%82%20%222026.04.09%20%E6%98%9F%E6%9C%9F%E5%9B%9B%22%EF%BC%89%E3%80%82%E7%94%B1%E6%96%BC%20%60cachedText%60%20%E4%B8%8D%E7%82%BA%20None%EF%BC%8C%60line.py%60%20%E4%B8%AD%E7%9A%84%20%60_copyAndReadMessage%60%20%E5%B0%B1%E6%9C%83%E7%9B%B4%E6%8E%A5%E6%92%AD%E5%A0%B1%E9%8C%AF%E8%AA%A4%E5%85%A7%E5%AE%B9%EF%BC%8C%E4%B8%94**%E4%B8%8D%E6%9C%83%E9%80%B2%E8%A1%8C%20copy-read%20%E7%9A%84%E5%9B%9E%E9%80%80%E6%B5%81%E7%A8%8B**%E3%80%82%0A%0A%E8%80%83%E6%85%AE%E5%9C%A8%E6%89%BE%E4%B8%8D%E5%88%B0%E6%97%A5%E6%9C%9F%E5%88%86%E9%9A%94%E7%AC%A6%E8%99%9F%E6%99%82%E8%B7%B3%E9%81%8E%E6%97%A9%E6%9C%9F%E8%BF%94%E5%9B%9E%EF%BC%8C%E6%94%B9%E7%82%BA%E8%90%BD%E5%85%A5%E4%B8%80%E8%88%AC%E8%A8%8A%E6%81%AF%E8%A9%95%E5%88%86%E6%B5%81%E7%A8%8B%EF%BC%8C%E6%88%96%E5%85%88%E7%A2%BA%E8%AA%8D%E5%AE%8C%E6%95%B4%20OCR%20%E6%96%87%E5%AD%97%EF%BC%88%E5%8E%BB%E9%99%A4%E6%99%82%E9%96%93%E5%BE%8C%EF%BC%89%E7%A2%BA%E5%AF%A6%E5%8F%AA%E5%89%A9%E4%B8%8B%E6%97%A5%E6%9C%9F%E7%89%87%E6%AE%B5%EF%BC%8C%E5%86%8D%E8%A6%96%E4%B9%8B%E7%82%BA%E6%98%8E%E7%A2%BA%E7%9A%84%E6%97%A5%E6%9C%9F%E9%8C%A8%E5%AE%9A%E3%80%82%0A%0A%23%23%23%20Issue%202%20of%202%0Aaddon%2FappModules%2F_chatCache.py%3A320-322%0A**%E5%A4%A7%E5%9E%8B%E5%BF%AB%E5%8F%96%E7%9A%84%20LCS%20%E6%95%88%E8%83%BD%E5%95%8F%E9%A1%8C**%0A%0A%E7%95%B6%E7%B2%BE%E7%A2%BA%E5%AD%90%E5%AD%97%E4%B8%B2%E6%AF%94%E5%B0%8D%E5%A4%B1%E6%95%97%E6%99%82%EF%BC%8C%60_longestCommonSubstring%60%20%E6%9C%83%E5%B0%8D%E5%BF%AB%E5%8F%96%E4%B8%AD**%E6%AF%8F%E4%B8%80%E5%89%87%E8%A8%8A%E6%81%AF**%E9%83%BD%E5%9F%B7%E8%A1%8C%20O%28m%C3%97n%29%20%E7%9A%84%E9%81%8B%E7%AE%97%E3%80%82%E5%9C%A8%E4%B8%80%E5%80%8B%E6%9C%89%20500%20%E5%89%87%E8%A8%8A%E6%81%AF%EF%BC%88%E6%AF%8F%E5%89%87%E5%B9%B3%E5%9D%87%2050%20%E5%AD%97%EF%BC%89%E3%80%81OCR%20%E6%96%87%E5%AD%97%E7%B4%84%20200%20%E5%AD%97%E7%9A%84%E8%81%8A%E5%A4%A9%E5%AE%A4%E4%B8%AD%EF%BC%8C%E6%9C%80%E5%B7%AE%E6%83%85%E6%B3%81%E9%9C%80%E8%A6%81%E7%B4%84%20500%20%C3%97%2050%20%C3%97%20200%20%3D%205%2C000%2C000%20%E6%AC%A1%E5%AD%97%E5%85%83%E6%AF%94%E8%BC%83%EF%BC%8C%E5%8F%AF%E8%83%BD%E5%9C%A8%20CPython%20%E4%B8%AD%E9%80%A0%E6%88%90%E5%8F%AF%E5%AF%9F%E8%A6%BA%E7%9A%84%E5%BB%B6%E9%81%B2%EF%BC%88%3E%20100%20ms%EF%BC%89%EF%BC%8C%E4%BD%BF%E6%AF%8F%E6%AC%A1%E8%A8%8A%E6%81%AF%E6%B3%A1%E6%B3%A1%E5%B0%8E%E8%A6%BD%E9%83%BD%E6%9C%89%E5%81%9C%E9%A0%93%E6%84%9F%E3%80%82%0A%0A%E5%8F%AF%E8%80%83%E6%85%AE%E5%83%85%E5%9C%A8%20OCR%20%E6%96%87%E5%AD%97%E5%B7%B2%E9%80%9A%E9%81%8E%E6%9C%80%E4%BD%8E%E9%95%B7%E5%BA%A6%E7%AF%A9%E9%81%B8%E5%BE%8C%E6%89%8D%E5%95%9F%E7%94%A8%20LCS%EF%BC%8C%E6%88%96%E5%9C%A8%20LCS%20%E8%BF%B4%E5%9C%88%E4%B8%AD%E5%8A%A0%E5%85%A5%E6%8F%90%E5%89%8D%E7%B5%82%E6%AD%A2%EF%BC%88%E8%8B%A5%E7%9B%AE%E5%89%8D%E6%9C%80%E9%95%B7%E5%80%BC%E5%B7%B2%E8%B6%85%E9%81%8E%20%60ocrNorm%60%20%E7%9A%84%E4%B8%80%E5%AE%9A%E6%AF%94%E4%BE%8B%E5%8D%B3%E5%8F%AF%E6%8F%90%E5%89%8D%E9%80%80%E5%87%BA%EF%BC%89%E3%80%82%0A%0A&repo=keyang556%2Flinedesktopnvda&pr=67&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Felastic-burnell-5de272%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Felastic-burnell-5de272%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aaddon%2FappModules%2F_chatCache.py%3A276-287%0A**%E6%97%A5%E6%9C%9F%E7%89%87%E6%AE%B5%E7%9A%84%E6%97%A9%E6%9C%9F%E8%BF%94%E5%9B%9E%E5%8F%AF%E8%83%BD%E9%8C%AF%E8%AA%A4%E5%9C%B0%E6%AF%94%E5%B0%8D%E5%88%B0%E4%B8%80%E8%88%AC%E8%A8%8A%E6%81%AF**%0A%0A%60_DATE_FRAGMENT_RE%60%EF%BC%88%60%5Cd%7B4%7D%5C.%5Cd%7B2%7D%5C.%5Cd%7B2%7D%60%EF%BC%89%E5%8F%AA%E8%A6%81%E5%9C%A8%20OCR%20%E6%96%87%E5%AD%97%E4%B8%AD%E5%81%B5%E6%B8%AC%E5%88%B0%E6%97%A5%E6%9C%9F%E6%A0%BC%E5%BC%8F%EF%BC%8C%E5%B0%B1%E6%9C%83%E7%AB%8B%E5%8D%B3%E8%BF%94%E5%9B%9E%E6%97%A5%E6%9C%9F%E5%88%86%E9%9A%94%E7%AC%A6%E8%99%9F%E4%B8%A6%E8%B7%B3%E9%81%8E%E4%B8%80%E8%88%AC%E8%A8%8A%E6%81%AF%E7%9A%84%E8%A9%95%E5%88%86%E6%B5%81%E7%A8%8B%E3%80%82%E5%A6%82%E6%9E%9C%E4%BD%BF%E7%94%A8%E8%80%85%E8%81%9A%E7%84%A6%E7%9A%84%E8%A8%8A%E6%81%AF%E6%B3%A1%E6%B3%A1%E5%85%A7%E5%AE%B9%E6%81%B0%E5%A5%BD%E5%8C%85%E5%90%AB%E6%AD%A4%E6%A0%BC%E5%BC%8F%E7%9A%84%E6%97%A5%E6%9C%9F%EF%BC%88%E4%BE%8B%E5%A6%82%20%222026.04.09%20%E8%A6%81%E8%A8%98%E5%BE%97%E5%96%9D%E6%B0%B4%22%EF%BC%89%EF%BC%8C%60lookupMessage%60%20%E6%9C%83%E8%BF%94%E5%9B%9E%E7%95%B6%E5%A4%A9%E7%9A%84%E6%97%A5%E6%9C%9F%E5%88%86%E9%9A%94%E7%AC%A6%E8%99%9F%E6%96%87%E5%AD%97%EF%BC%88%E4%BE%8B%E5%A6%82%20%222026.04.09%20%E6%98%9F%E6%9C%9F%E5%9B%9B%22%EF%BC%89%E3%80%82%E7%94%B1%E6%96%BC%20%60cachedText%60%20%E4%B8%8D%E7%82%BA%20None%EF%BC%8C%60line.py%60%20%E4%B8%AD%E7%9A%84%20%60_copyAndReadMessage%60%20%E5%B0%B1%E6%9C%83%E7%9B%B4%E6%8E%A5%E6%92%AD%E5%A0%B1%E9%8C%AF%E8%AA%A4%E5%85%A7%E5%AE%B9%EF%BC%8C%E4%B8%94**%E4%B8%8D%E6%9C%83%E9%80%B2%E8%A1%8C%20copy-read%20%E7%9A%84%E5%9B%9E%E9%80%80%E6%B5%81%E7%A8%8B**%E3%80%82%0A%0A%E8%80%83%E6%85%AE%E5%9C%A8%E6%89%BE%E4%B8%8D%E5%88%B0%E6%97%A5%E6%9C%9F%E5%88%86%E9%9A%94%E7%AC%A6%E8%99%9F%E6%99%82%E8%B7%B3%E9%81%8E%E6%97%A9%E6%9C%9F%E8%BF%94%E5%9B%9E%EF%BC%8C%E6%94%B9%E7%82%BA%E8%90%BD%E5%85%A5%E4%B8%80%E8%88%AC%E8%A8%8A%E6%81%AF%E8%A9%95%E5%88%86%E6%B5%81%E7%A8%8B%EF%BC%8C%E6%88%96%E5%85%88%E7%A2%BA%E8%AA%8D%E5%AE%8C%E6%95%B4%20OCR%20%E6%96%87%E5%AD%97%EF%BC%88%E5%8E%BB%E9%99%A4%E6%99%82%E9%96%93%E5%BE%8C%EF%BC%89%E7%A2%BA%E5%AF%A6%E5%8F%AA%E5%89%A9%E4%B8%8B%E6%97%A5%E6%9C%9F%E7%89%87%E6%AE%B5%EF%BC%8C%E5%86%8D%E8%A6%96%E4%B9%8B%E7%82%BA%E6%98%8E%E7%A2%BA%E7%9A%84%E6%97%A5%E6%9C%9F%E9%8C%A8%E5%AE%9A%E3%80%82%0A%0A%23%23%23%20Issue%202%20of%202%0Aaddon%2FappModules%2F_chatCache.py%3A320-322%0A**%E5%A4%A7%E5%9E%8B%E5%BF%AB%E5%8F%96%E7%9A%84%20LCS%20%E6%95%88%E8%83%BD%E5%95%8F%E9%A1%8C**%0A%0A%E7%95%B6%E7%B2%BE%E7%A2%BA%E5%AD%90%E5%AD%97%E4%B8%B2%E6%AF%94%E5%B0%8D%E5%A4%B1%E6%95%97%E6%99%82%EF%BC%8C%60_longestCommonSubstring%60%20%E6%9C%83%E5%B0%8D%E5%BF%AB%E5%8F%96%E4%B8%AD**%E6%AF%8F%E4%B8%80%E5%89%87%E8%A8%8A%E6%81%AF**%E9%83%BD%E5%9F%B7%E8%A1%8C%20O%28m%C3%97n%29%20%E7%9A%84%E9%81%8B%E7%AE%97%E3%80%82%E5%9C%A8%E4%B8%80%E5%80%8B%E6%9C%89%20500%20%E5%89%87%E8%A8%8A%E6%81%AF%EF%BC%88%E6%AF%8F%E5%89%87%E5%B9%B3%E5%9D%87%2050%20%E5%AD%97%EF%BC%89%E3%80%81OCR%20%E6%96%87%E5%AD%97%E7%B4%84%20200%20%E5%AD%97%E7%9A%84%E8%81%8A%E5%A4%A9%E5%AE%A4%E4%B8%AD%EF%BC%8C%E6%9C%80%E5%B7%AE%E6%83%85%E6%B3%81%E9%9C%80%E8%A6%81%E7%B4%84%20500%20%C3%97%2050%20%C3%97%20200%20%3D%205%2C000%2C000%20%E6%AC%A1%E5%AD%97%E5%85%83%E6%AF%94%E8%BC%83%EF%BC%8C%E5%8F%AF%E8%83%BD%E5%9C%A8%20CPython%20%E4%B8%AD%E9%80%A0%E6%88%90%E5%8F%AF%E5%AF%9F%E8%A6%BA%E7%9A%84%E5%BB%B6%E9%81%B2%EF%BC%88%3E%20100%20ms%EF%BC%89%EF%BC%8C%E4%BD%BF%E6%AF%8F%E6%AC%A1%E8%A8%8A%E6%81%AF%E6%B3%A1%E6%B3%A1%E5%B0%8E%E8%A6%BD%E9%83%BD%E6%9C%89%E5%81%9C%E9%A0%93%E6%84%9F%E3%80%82%0A%0A%E5%8F%AF%E8%80%83%E6%85%AE%E5%83%85%E5%9C%A8%20OCR%20%E6%96%87%E5%AD%97%E5%B7%B2%E9%80%9A%E9%81%8E%E6%9C%80%E4%BD%8E%E9%95%B7%E5%BA%A6%E7%AF%A9%E9%81%B8%E5%BE%8C%E6%89%8D%E5%95%9F%E7%94%A8%20LCS%EF%BC%8C%E6%88%96%E5%9C%A8%20LCS%20%E8%BF%B4%E5%9C%88%E4%B8%AD%E5%8A%A0%E5%85%A5%E6%8F%90%E5%89%8D%E7%B5%82%E6%AD%A2%EF%BC%88%E8%8B%A5%E7%9B%AE%E5%89%8D%E6%9C%80%E9%95%B7%E5%80%BC%E5%B7%B2%E8%B6%85%E9%81%8E%20%60ocrNorm%60%20%E7%9A%84%E4%B8%80%E5%AE%9A%E6%AF%94%E4%BE%8B%E5%8D%B3%E5%8F%AF%E6%8F%90%E5%89%8D%E9%80%80%E5%87%BA%EF%BC%89%E3%80%82%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: addon/appModules/_chatCache.py
Line: 276-287

Comment:
**日期片段的早期返回可能錯誤地比對到一般訊息**

`_DATE_FRAGMENT_RE`（`\d{4}\.\d{2}\.\d{2}`）只要在 OCR 文字中偵測到日期格式，就會立即返回日期分隔符號並跳過一般訊息的評分流程。如果使用者聚焦的訊息泡泡內容恰好包含此格式的日期（例如 "2026.04.09 要記得喝水"），`lookupMessage` 會返回當天的日期分隔符號文字（例如 "2026.04.09 星期四"）。由於 `cachedText` 不為 None，`line.py` 中的 `_copyAndReadMessage` 就會直接播報錯誤內容，且**不會進行 copy-read 的回退流程**。

考慮在找不到日期分隔符號時跳過早期返回，改為落入一般訊息評分流程，或先確認完整 OCR 文字（去除時間後）確實只剩下日期片段，再視之為明確的日期錨定。

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: addon/appModules/_chatCache.py
Line: 320-322

Comment:
**大型快取的 LCS 效能問題**

當精確子字串比對失敗時，`_longestCommonSubstring` 會對快取中**每一則訊息**都執行 O(m×n) 的運算。在一個有 500 則訊息（每則平均 50 字）、OCR 文字約 200 字的聊天室中，最差情況需要約 500 × 50 × 200 = 5,000,000 次字元比較，可能在 CPython 中造成可察覺的延遲（> 100 ms），使每次訊息泡泡導覽都有停頓感。

可考慮僅在 OCR 文字已通過最低長度篩選後才啟用 LCS，或在 LCS 迴圈中加入提前終止（若目前最長值已超過 `ocrNorm` 的一定比例即可提前退出）。

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Reset \_messageReaderBackgroundCache in m..."](https://github.com/keyang556/linedesktopnvda/commit/e44e70349de2d15e85ae8ccc9d2006661bf16a9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30133930)</sub>

<!-- /greptile_comment -->