### PR TITLE
Fix sidebar boundary detection for high-DPI and maximized windows

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2701,6 +2701,34 @@ def _getDpiScale(hwnd=None):
 	return scale
 
 
+# Physical-pixel cap for the right edge of LINE's left sidebar (icons column +
+# chat list panel). Empirically, LINE renders the sidebar at a fixed physical
+# pixel width regardless of DPI scaling (a Qt quirk on Windows): observed at
+# both 96 DPI and 144 DPI maximized the sidebar still ends near X=547. So we
+# do NOT multiply by DPI scale — that double-counts and lets the cap drift
+# back into the message area when the window is maximized at high DPI.
+_LINE_SIDEBAR_RIGHT_BASE = 540
+
+
+def _getSidebarRightBoundary(wndRect, hwnd=None, percentage=0.45):
+	"""Return the screen-space X separating LINE's sidebar from the message area.
+
+	LINE keeps the sidebar at a fixed physical-pixel width regardless of window
+	size or DPI, so a pure ``wndWidth * percentage`` threshold lands deep in the
+	message area when the window is maximized. We cap the percentage at the
+	empirical sidebar edge so the same code path works for standard windows,
+	maximized windows, and high-DPI configurations.
+	"""
+	try:
+		wndLeft = int(wndRect.left)
+		wndWidth = int(wndRect.right - wndRect.left)
+	except Exception:
+		return None
+	if wndWidth <= 0:
+		return None
+	return wndLeft + min(int(wndWidth * percentage), _LINE_SIDEBAR_RIGHT_BASE)
+
+
 def _scheduleQueryAndSpeakUIAFocus(delay=100):
 	"""Schedule a focus query, dropping stale callbacks when navigation repeats quickly."""
 	global _focusQueryRequestId
@@ -3939,9 +3967,8 @@ def _isInChatListContext(handler):
 					if hwnd:
 						wndRect = ctypes.wintypes.RECT()
 						ctypes.windll.user32.GetWindowRect(hwnd, ctypes.byref(wndRect))
-						wndWidth = wndRect.right - wndRect.left
-						if wndWidth > 0:
-							sidebarRight = wndRect.left + int(wndWidth * 0.45)
+						sidebarRight = _getSidebarRightBoundary(wndRect, hwnd)
+						if sidebarRight is not None:
 							listRect = listEl.CurrentBoundingRectangle
 							if listRect.left >= sidebarRight:
 								# List is on the right side — message list, not chat list
@@ -4021,12 +4048,9 @@ def _findChatListFromWindow(handler):
 		# Get window rect to identify sidebar area
 		wndRect = ctypes.wintypes.RECT()
 		ctypes.windll.user32.GetWindowRect(hwnd, ctypes.byref(wndRect))
-		wndWidth = wndRect.right - wndRect.left
-		if wndWidth <= 0:
+		sidebarRight = _getSidebarRightBoundary(wndRect, hwnd)
+		if sidebarRight is None:
 			return None, None
-
-		# The sidebar is roughly the left 35% of the window
-		sidebarRight = wndRect.left + int(wndWidth * 0.45)
 
 		# Get root UIA element for the window
 		rootEl = handler.clientObject.ElementFromHandle(hwnd)
@@ -4291,11 +4315,11 @@ def _queryAndSpeakUIAFocus():
 						lineHwnd,
 						ctypes.byref(wr),
 					)
-					winWidth = int(wr.right - wr.left)
-					winLeft = int(wr.left)
-					# Message list items are in the right portion
-					# (element left edge > 35% of window width from left)
-					if winWidth > 0 and (elLeft - winLeft) > winWidth * 0.35:
+					# Message list items sit to the right of LINE's sidebar
+					# (icons + chat list). The boundary uses a fixed pixel cap
+					# so the test still works when the window is maximized.
+					boundary = _getSidebarRightBoundary(wr, lineHwnd, percentage=0.35)
+					if boundary is not None and elLeft >= boundary:
 						isMessageItem = True
 				except Exception:
 					pass

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2704,13 +2704,14 @@ def _getDpiScale(hwnd=None):
 # Physical-pixel cap for the right edge of LINE's left sidebar (icons column +
 # chat list panel). Empirically, LINE renders the sidebar at a fixed physical
 # pixel width regardless of DPI scaling (a Qt quirk on Windows): observed at
-# both 96 DPI and 144 DPI maximized the sidebar still ends near X=547. So we
-# do NOT multiply by DPI scale — that double-counts and lets the cap drift
-# back into the message area when the window is maximized at high DPI.
+# both 96 DPI and 144 DPI maximized the sidebar still ends near X=547. We cap
+# conservatively at 540 (observed edge ≈ 547, 7 px safety margin) so we do NOT
+# multiply by DPI scale — that double-counts and lets the cap drift back into
+# the message area when the window is maximized at high DPI.
 _LINE_SIDEBAR_RIGHT_BASE = 540
 
 
-def _getSidebarRightBoundary(wndRect, hwnd=None, percentage=0.45):
+def _getSidebarRightBoundary(wndRect, _hwnd=None, percentage=0.45):
 	"""Return the screen-space X separating LINE's sidebar from the message area.
 
 	LINE keeps the sidebar at a fixed physical-pixel width regardless of window
@@ -2718,6 +2719,8 @@ def _getSidebarRightBoundary(wndRect, hwnd=None, percentage=0.45):
 	message area when the window is maximized. We cap the percentage at the
 	empirical sidebar edge so the same code path works for standard windows,
 	maximized windows, and high-DPI configurations.
+
+	``_hwnd`` is reserved for future per-monitor DPI queries and is not used yet.
 	"""
 	try:
 		wndLeft = int(wndRect.left)
@@ -4318,6 +4321,8 @@ def _queryAndSpeakUIAFocus():
 					# Message list items sit to the right of LINE's sidebar
 					# (icons + chat list). The boundary uses a fixed pixel cap
 					# so the test still works when the window is maximized.
+					# >= is intentional: an element whose left edge lands exactly
+					# on the boundary belongs to the message area, not the sidebar.
 					boundary = _getSidebarRightBoundary(wr, lineHwnd, percentage=0.35)
 					if boundary is not None and elLeft >= boundary:
 						isMessageItem = True


### PR DESCRIPTION
## What changed

Replaced three inline `wndWidth * percentage` sidebar-boundary calculations with a new helper function `_getSidebarRightBoundary()` that caps the percentage-based estimate at an empirical physical-pixel maximum.

### Root cause

LINE's Qt-based sidebar renders at a **fixed physical-pixel width** regardless of DPI scaling or window size. A pure `wndWidth * 0.45` threshold works fine for small windows but overshoots into the message area when the window is **maximized at high DPI** (e.g. 150% / 144 DPI), causing:

- `_isInChatListContext` to misidentify message-list elements as chat-list elements
- `_findChatListFromWindow` to search the wrong window region
- `_queryAndSpeakUIAFocus` to fail the message-item classification check

### Fix

Added `_LINE_SIDEBAR_RIGHT_BASE = 540` (empirically observed physical-pixel sidebar edge at both 96 DPI and 144 DPI, maximized) and a helper:

```python
def _getSidebarRightBoundary(wndRect, hwnd=None, percentage=0.45):
    return wndLeft + min(int(wndWidth * percentage), _LINE_SIDEBAR_RIGHT_BASE)
```

The `min()` cap ensures the boundary never drifts beyond the actual sidebar edge for large windows, while the percentage path still handles unusually small windows correctly.

## Affected code paths

| Function | Old threshold | New threshold |
|---|---|---|
| `_isInChatListContext` | `wndWidth * 0.45` | `_getSidebarRightBoundary(wndRect, hwnd)` |
| `_findChatListFromWindow` | `wndWidth * 0.45` | `_getSidebarRightBoundary(wndRect, hwnd)` |
| `_queryAndSpeakUIAFocus` | `winWidth * 0.35` | `_getSidebarRightBoundary(wr, lineHwnd, percentage=0.35)` |

## Testing

- Verify chat-list navigation works at 100% DPI (96 DPI) with LINE in a normal window
- Verify chat-list navigation works at 150% DPI (144 DPI) with LINE maximized
- Verify message reading still triggers correctly when focused on a message-list item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 將三處分散的 `wndWidth * percentage` 側邊欄邊界計算，整合為新的輔助函式 `_getSidebarRightBoundary()`，並以常數 `_LINE_SIDEBAR_RIGHT_BASE = 540` 為 LINE 側邊欄固定像素寬度設定上限，修正了在高 DPI 或最大化視窗下邊界計算過大的問題。整體邏輯正確，參數命名 `_hwnd` 也已表明其為保留用途，先前的審查意見均已獲回應。

<h3>Confidence Score: 5/5</h3>

此 PR 可安全合併，修正邏輯正確，無阻塞性問題。

先前審查意見均已回應（`hwnd` 改為 `_hwnd`、常數與注釋的差異已在注釋中說明保留空間、`>=` 的刻意改動已有注釋說明）；剩餘項目皆為 P2 等級，不影響合併。

無需特別關注的檔案。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 `_LINE_SIDEBAR_RIGHT_BASE = 540` 常數與 `_getSidebarRightBoundary()` 輔助函式，並在三個函式中替換原有的行內百分比計算；邏輯正確，`_hwnd` 參數已以底線前綴標記為保留用途。 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["呼叫 _getSidebarRightBoundary(wndRect, _hwnd, percentage)"] --> B{讀取 wndLeft / wndWidth}
    B -- 例外 --> C["回傳 None"]
    B -- 成功 --> D{wndWidth <= 0?}
    D -- 是 --> C
    D -- 否 --> E["計算 percentage 值\nint(wndWidth * percentage)"]
    E --> F["取 min(percentage值, _LINE_SIDEBAR_RIGHT_BASE=540)"]
    F --> G["回傳 wndLeft + min值\n= 側邊欄右邊界 (絕對螢幕 X)"]
    G --> H{"呼叫方 (三處)"}
    H --> I["_isInChatListContext\n比較 listRect.left >= sidebarRight"]
    H --> J["_findChatListFromWindow\n限制 UIA 搜尋範圍"]
    H --> K["_queryAndSpeakUIAFocus\n判斷 elLeft >= boundary\n(percentage=0.35)"]
```

<sub>Reviews (2): Last reviewed commit: ["Address greptile review comments on \_get..."](https://github.com/keyang556/linedesktopnvda/commit/48f8a4128b7526a61d4e5b23f52d23ec662b497c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30280271)</sub>

<!-- /greptile_comment -->