### PR TITLE
Improve chat room name detection and cache file naming

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -3506,7 +3506,8 @@ def _ocrReadElementText(rawElement, appModuleRef=None, preferCallAnnouncement=Fa
 						if preferCallAnnouncement:
 							announcement = _getCallAnnouncementFromOcr(ocrText)
 						log.info(f"LINE OCR nav result: {ocrText!r}")
-						_storeChatNameFromText(ocrText)
+						if not preferCallAnnouncement:
+							_storeChatNameFromText(ocrText)
 						speech.cancelSpeech()
 						ui.message(announcement or ocrText)
 					else:
@@ -8594,8 +8595,6 @@ class AppModule(appModuleHandler.AppModule):
 				stem, ext = os.path.splitext(os.path.basename(suggested))
 				if ext.lower() == ".txt" and stem.startswith("[LINE]"):
 					dialogStem = stem[len("[LINE]") :].strip()
-				elif stem:
-					dialogStem = stem.strip()
 				log.info(
 					f"LINE: save dialog suggested filename {suggested!r}, extracted stem {dialogStem!r}",
 				)

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -8235,7 +8235,7 @@ class AppModule(appModuleHandler.AppModule):
 					base = os.path.basename(tempPath)
 					stem, ext = os.path.splitext(base)
 					if ext.lower() == ".txt" and stem.startswith("[LINE]"):
-						nameFromFile = stem[len("[LINE]"):].strip()
+						nameFromFile = stem[len("[LINE]") :].strip()
 						if nameFromFile:
 							log.info(f"LINE: using chat name from cache file {nameFromFile!r}")
 							ui.message(nameFromFile)
@@ -8593,7 +8593,7 @@ class AppModule(appModuleHandler.AppModule):
 				suggested = readBuf.value or ""
 				stem, ext = os.path.splitext(os.path.basename(suggested))
 				if ext.lower() == ".txt" and stem.startswith("[LINE]"):
-					dialogStem = stem[len("[LINE]"):].strip()
+					dialogStem = stem[len("[LINE]") :].strip()
 				elif stem:
 					dialogStem = stem.strip()
 				log.info(

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -3506,6 +3506,7 @@ def _ocrReadElementText(rawElement, appModuleRef=None, preferCallAnnouncement=Fa
 						if preferCallAnnouncement:
 							announcement = _getCallAnnouncementFromOcr(ocrText)
 						log.info(f"LINE OCR nav result: {ocrText!r}")
+						_storeChatNameFromText(ocrText)
 						speech.cancelSpeech()
 						ui.message(announcement or ocrText)
 					else:
@@ -8214,21 +8215,35 @@ class AppModule(appModuleHandler.AppModule):
 	# ── Read chat room name ────────────────────────────────────────────
 
 	def _readChatRoomName(self):
-		"""OCR the chat header area to read the current chat room name.
+		"""Read the current chat room name.
 
-		LINE's Qt6 renders the chat room name (contact or group name)
-		in the header bar, but does not expose it via UIA.
-		We calculate the header title region from window geometry and
-		use Windows OCR to extract the text.
-
-		The header layout (left to right):
-		  - Back arrow / avatar (left side)
-		  - Chat room name (center area)
-		  - Toolbar icons on the right (search, phone, notes, menu)
+		Priority order:
+		  1. Cache file name [LINE]姓名.txt (after NVDA+Windows+U) — extract the
+		     name segment between the [LINE] prefix and the .txt suffix.
+		  2. Header-area OCR — fallback when no cache exists.
 		"""
 		import ctypes
 		import ctypes.wintypes
 
+		# 1. Background cache file name (NVDA+Windows+U was used for this room)
+		try:
+			from . import _chatCache
+
+			if _chatCache.isActive():
+				tempPath = _chatCache.getTempPath()
+				if tempPath:
+					base = os.path.basename(tempPath)
+					stem, ext = os.path.splitext(base)
+					if ext.lower() == ".txt" and stem.startswith("[LINE]"):
+						nameFromFile = stem[len("[LINE]"):].strip()
+						if nameFromFile:
+							log.info(f"LINE: using chat name from cache file {nameFromFile!r}")
+							ui.message(nameFromFile)
+							return
+		except Exception:
+			log.debug("LINE: chat cache file-name lookup failed", exc_info=True)
+
+		# 2. Header-area OCR (fallback)
 		hwnd = ctypes.windll.user32.GetForegroundWindow()
 		if not hwnd:
 			ui.message(_("找不到 LINE 視窗"))
@@ -8285,7 +8300,6 @@ class AppModule(appModuleHandler.AppModule):
 			f"LINE: OCR chat room name area: ({nameLeft},{nameTop}) {nameW}x{nameH}, scale={scale:.2f}",
 		)
 
-		# Use _ocrWindowArea with the calculated region
 		try:
 			ocrText = self._ocrWindowArea(
 				hwnd,
@@ -8556,11 +8570,62 @@ class AppModule(appModuleHandler.AppModule):
 				ui.message(_("未偵測到儲存對話框"))
 			return
 
+		# Find the filename edit control in the Save dialog
+		# The file dialog has a ComboBoxEx32 > ComboBox > Edit hierarchy
+		editHwnd = self._findSaveDialogEdit(dialogHwnd)
+		if not editHwnd:
+			self._messageReaderPending = False
+			self._messageReaderBackgroundCache = False
+			ui.message(_("無法操作儲存對話框"))
+			return
+
+		# Read LINE's pre-filled filename — it's [LINE]{chatRoomName}.txt and
+		# carries the authoritative room name straight from LINE (much cleaner
+		# than OCR-derived names that include unread badges like "( ) 9").
+		WM_GETTEXT = 0x000D
+		WM_GETTEXTLENGTH = 0x000E
+		dialogStem = ""
+		try:
+			textLen = ctypes.windll.user32.SendMessageW(editHwnd, WM_GETTEXTLENGTH, 0, 0)
+			if textLen > 0:
+				readBuf = ctypes.create_unicode_buffer(textLen + 1)
+				ctypes.windll.user32.SendMessageW(editHwnd, WM_GETTEXT, textLen + 1, readBuf)
+				suggested = readBuf.value or ""
+				stem, ext = os.path.splitext(os.path.basename(suggested))
+				if ext.lower() == ".txt" and stem.startswith("[LINE]"):
+					dialogStem = stem[len("[LINE]"):].strip()
+				elif stem:
+					dialogStem = stem.strip()
+				log.info(
+					f"LINE: save dialog suggested filename {suggested!r}, extracted stem {dialogStem!r}",
+				)
+		except Exception as e:
+			log.debug(f"LINE: could not read save dialog edit text: {e}", exc_info=True)
+
+		# Adopt the dialog's chat name so the cache and any later NVDA+Windows+T
+		# read use the LINE-authoritative name, not a stale list-nav OCR value.
+		if dialogStem:
+			global _currentChatRoomName
+			if _currentChatRoomName != dialogStem:
+				log.info(
+					f"LINE: updating chat room name from save dialog: {_currentChatRoomName!r} -> {dialogStem!r}",
+				)
+				_currentChatRoomName = dialogStem
+
 		# Build temp file path (use system temp dir to avoid locking the addon folder).
 		# Use a separate file when caching to background so an open reader window
 		# (cleanupPath bound) does not race with the cache file.
 		if getattr(self, "_messageReaderBackgroundCache", False):
-			fileName = "lineDesktop_chat_cache.txt"
+			# Name cache files [LINE]姓名.txt so users can identify which room
+			# each cache belongs to. Prefer the dialog stem (LINE's own name)
+			# over _currentChatRoomName which may be empty or list-nav noise.
+			candidate = dialogStem or (_currentChatRoomName or "").strip()
+			safeName = re.sub(r'[\\/:*?"<>|]', "_", candidate) if candidate else ""
+			safeName = safeName.rstrip(" .")
+			if safeName:
+				fileName = f"[LINE]{safeName}.txt"
+			else:
+				fileName = "lineDesktop_chat_cache.txt"
 		else:
 			fileName = "lineDesktop_chat_export.txt"
 		savePath = os.path.join(tempfile.gettempdir(), fileName)
@@ -8572,15 +8637,6 @@ class AppModule(appModuleHandler.AppModule):
 				os.remove(savePath)
 		except Exception as e:
 			log.warning(f"LINE: could not pre-delete chat export: {e}")
-
-		# Find the filename edit control in the Save dialog
-		# The file dialog has a ComboBoxEx32 > ComboBox > Edit hierarchy
-		editHwnd = self._findSaveDialogEdit(dialogHwnd)
-		if not editHwnd:
-			self._messageReaderPending = False
-			self._messageReaderBackgroundCache = False
-			ui.message(_("無法操作儲存對話框"))
-			return
 
 		# Set the filename
 		WM_SETTEXT = 0x000C


### PR DESCRIPTION
## Summary

- **Cache file naming**: NVDA+Windows+U now names cache files `[LINE]姓名.txt` by reading LINE's own pre-filled filename from the Windows Save dialog.
- **NVDA+Windows+T priority order**: Now reads the chat room name from the cache filename first (`[LINE]姓名.txt` → extract name segment), falling back to header-area OCR only when no cache is active.
- **Tab navigation stores room name**: `_ocrReadElementText` now calls `_storeChatNameFromText` so navigating through the chat list via Tab keeps `_currentChatRoomName` populated.
- **Authoritative name adoption**: The save dialog edit control is read *before* being overridden, updating `_currentChatRoomName` with LINE's clean room name for subsequent use.

## Test plan

- [x] Open a LINE chat room, press NVDA+Windows+U to cache — verify temp file is named `[LINE]姓名.txt` with the correct room name
- [ ] Press NVDA+Windows+T — verify it reads the name from the cache filename without OCR
- [ ] Navigate chat list with Tab — verify NVDA+Windows+T still works correctly
- [ ] Switch to a different chat room — verify cache clears and NVDA+Windows+T falls back to OCR
- [ ] Test with group chats and 1-on-1 chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 改善了聊天室名稱偵測與快取檔案命名：NVDA+Windows+U 會讀取 LINE 儲存對話框預填的 `[LINE]姓名.txt` 作為檔名，NVDA+Windows+T 優先從快取檔名取得聊天室名稱而非 OCR；Tab 導覽時也會透過新增的 `_storeChatNameFromText` 呼叫更新 `_currentChatRoomName`。

上一輪審查指出的兩個問題均已修正：`preferCallAnnouncement=True` 守衛已正確阻止訊息氣泡 OCR 覆蓋聊天室名稱，且 `elif stem:` fallback 已移除（只接受 `[LINE]XXX.txt` 格式）。

<h3>Confidence Score: 5/5</h3>

此 PR 邏輯清晰，前兩輪審查的問題均已完整解決，可安全合併。

兩個先前標記的 P1 問題（`elif stem:` fallback 及訊息氣泡 OCR 覆蓋快取名稱）均已修正；新增的 `preferCallAnnouncement` 守衛、save dialog 讀取邏輯及快取檔名提取路徑均正確，無新發現的 P0/P1 問題。

無需特別關注的檔案。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增快取檔名讀取邏輯、save dialog 預填讀取、及 `_storeChatNameFromText` 呼叫於 `_ocrReadElementText`；前兩輪審查問題已完整修正，邏輯清晰無明顯新缺陷 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant NVDA as NVDA (line.py)
    participant LINE as LINE App
    participant Cache as _chatCache

    User->>NVDA: NVDA+Windows+U
    NVDA->>LINE: 觸發儲存對話框
    LINE-->>NVDA: 顯示 Save Dialog (預填 [LINE]姓名.txt)
    NVDA->>NVDA: _findSaveDialogEdit() 找到 Edit 控制項
    NVDA->>NVDA: WM_GETTEXT 讀取預填檔名
    NVDA->>NVDA: 提取 dialogStem ([LINE]→stem)
    NVDA->>NVDA: 更新 _currentChatRoomName = dialogStem
    NVDA->>NVDA: 建立 savePath = [LINE]姓名.txt
    NVDA->>LINE: WM_SETTEXT 設定檔案路徑
    LINE-->>NVDA: 儲存完成
    NVDA->>Cache: setCache(messages, savePath, chatRoomName)

    User->>NVDA: NVDA+Windows+T
    NVDA->>Cache: isActive()?
    Cache-->>NVDA: True
    NVDA->>Cache: getTempPath()
    Cache-->>NVDA: /tmp/[LINE]姓名.txt
    NVDA->>NVDA: 從檔名提取 nameFromFile
    NVDA->>User: 朗讀姓名 (無需 OCR)

    User->>NVDA: Tab 導覽聊天列表
    NVDA->>NVDA: _ocrReadElementText(listEl, preferCallAnnouncement=False)
    NVDA->>NVDA: _storeChatNameFromText(ocrText)
    NVDA->>Cache: onChatRoomChanged(newName)
    Cache->>Cache: 名稱不符 → clearCache()
```

<sub>Reviews (2): Last reviewed commit: ["Address greptile review comments"](https://github.com/keyang556/linedesktopnvda/commit/03daceb713fced298c8273a4f316cc1873dc6059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30432137)</sub>

<!-- /greptile_comment -->