### PR TITLE
Fix LINE more-options reminder state handling at 125% DPI

### DIFF
--- a/addon/appModules/_virtualWindows/chatMoreOptions.py
+++ b/addon/appModules/_virtualWindows/chatMoreOptions.py
@@ -273,8 +273,9 @@ _KNOWN_100_PERCENT_ROW_LAYOUT = (
 )
 _KNOWN_100_PERCENT_ROW_INDEX_BY_LABEL = dict(_KNOWN_100_PERCENT_ROW_LAYOUT)
 _REMINDER_TOGGLE_LABELS = {"開啟提醒", "關閉提醒"}
-for _label in _REMINDER_TOGGLE_LABELS:
-	_KNOWN_100_PERCENT_ROW_INDEX_BY_LABEL[_label] = 0
+_KNOWN_100_PERCENT_ROW_INDEX_BY_LABEL.update(
+	(label, 0) for label in _REMINDER_TOGGLE_LABELS
+)
 _KNOWN_100_PERCENT_ANCHOR_LABELS = {
 	"投票",
 	"儲存聊天",
@@ -288,7 +289,7 @@ def _inferKnownMenuRowIndex(
 	label: str | None,
 	rowRects: list[tuple[int, int, int, int]],
 ) -> int | None:
-	# At 100% LINE exposes an extra row-like separator between 投票 and 儲存聊天.
+	# At 100%/125% LINE exposes 12 row rects; the final bottom info row is non-actionable.
 	if len(rowRects) != 12:
 		return None
 	return _KNOWN_100_PERCENT_ROW_INDEX_BY_LABEL.get(label or "")

--- a/addon/appModules/_virtualWindows/chatMoreOptions.py
+++ b/addon/appModules/_virtualWindows/chatMoreOptions.py
@@ -91,37 +91,122 @@ def _matchMenuLabel(text: str) -> str | None:
 	return None
 
 
-def _extractRectLike(obj: Any) -> tuple[int, int, int, int] | None:
-	for attr in ("boundingRect", "boundingRectangle", "rect", "location", "bounds"):
-		rect = getattr(obj, attr, None)
-		if not rect:
-			continue
-		left = getattr(rect, "left", getattr(rect, "x", None))
-		top = getattr(rect, "top", getattr(rect, "y", None))
-		right = getattr(rect, "right", None)
-		bottom = getattr(rect, "bottom", None)
-		if right is None and left is not None:
-			width = getattr(rect, "width", None)
-			if width is not None:
-				right = left + width
-		if bottom is None and top is not None:
-			height = getattr(rect, "height", None)
-			if height is not None:
-				bottom = top + height
-		if None not in (left, top, right, bottom):
-			return (int(left), int(top), int(right), int(bottom))
+def _getObjectValue(obj: Any, *names: str) -> Any:
+	if obj is None:
+		return None
+	if isinstance(obj, dict):
+		for name in names:
+			value = obj.get(name)
+			if value is not None:
+				return value
+	for name in names:
+		value = getattr(obj, name, None)
+		if value is not None:
+			return value
+	return None
 
-	for attrs in (
-		("left", "top", "right", "bottom"),
-		("x", "y", "width", "height"),
+
+def _coerceRectNumber(value: Any) -> float | None:
+	if value is None:
+		return None
+	for attr in ("value", "Value"):
+		nested = getattr(value, attr, None)
+		if nested is not None and nested is not value:
+			value = nested
+			break
+	try:
+		return float(value)
+	except Exception:
+		return None
+
+
+def _coerceRectTuple(*values: Any) -> tuple[int, ...] | None:
+	coerced = []
+	for value in values:
+		number = _coerceRectNumber(value)
+		if number is None:
+			return None
+		coerced.append(int(round(number)))
+	return tuple(coerced)
+
+
+def _rectFromSequence(source: Any, preferXYWH: bool = False) -> tuple[int, int, int, int] | None:
+	if not isinstance(source, (list, tuple)) or len(source) < 4:
+		return None
+	flat = _coerceRectTuple(*source[:4])
+	if not flat:
+		return None
+	left, top, third, fourth = flat
+	edgeRect = (left, top, third, fourth) if third > left and fourth > top else None
+	sizeRect = (left, top, left + third, top + fourth) if third > 0 and fourth > 0 else None
+	for rect in (sizeRect, edgeRect) if preferXYWH else (edgeRect, sizeRect):
+		if rect and rect[2] > rect[0] and rect[3] > rect[1]:
+			return rect
+	return None
+
+
+def _rectFromObject(source: Any, preferXYWH: bool = False) -> tuple[int, int, int, int] | None:
+	if source is None:
+		return None
+	rect = _coerceRectTuple(
+		_getObjectValue(source, "left", "Left", "minX", "MinX", "x1", "X1"),
+		_getObjectValue(source, "top", "Top", "minY", "MinY", "y1", "Y1"),
+		_getObjectValue(source, "right", "Right", "maxX", "MaxX", "x2", "X2"),
+		_getObjectValue(source, "bottom", "Bottom", "maxY", "MaxY", "y2", "Y2"),
+	)
+	if rect and rect[2] > rect[0] and rect[3] > rect[1]:
+		return rect
+
+	for leftName, topName in (("x", "y"), ("X", "Y"), ("left", "top"), ("Left", "Top")):
+		rect = _coerceRectTuple(
+			_getObjectValue(source, leftName),
+			_getObjectValue(source, topName),
+			_getObjectValue(source, "width", "Width", "w", "W"),
+			_getObjectValue(source, "height", "Height", "h", "H"),
+		)
+		if rect and rect[2] > 0 and rect[3] > 0:
+			left, top, width, height = rect
+			return (left, top, left + width, top + height)
+
+	return _rectFromSequence(source, preferXYWH=preferXYWH)
+
+
+def _extractRectLike(obj: Any) -> tuple[int, int, int, int] | None:
+	for attr in (
+		"boundingRect",
+		"boundingRectangle",
+		"bounding_rect",
+		"bounding_rectangle",
+		"rect",
+		"location",
+		"bounds",
+		"box",
 	):
-		values = [getattr(obj, attr, None) for attr in attrs]
-		if any(value is None for value in values):
-			continue
-		left, top, third, fourth = values
-		if attrs[2] == "right":
-			return (int(left), int(top), int(third), int(fourth))
-		return (int(left), int(top), int(left + third), int(top + fourth))
+		rect = _rectFromObject(_getObjectValue(obj, attr), preferXYWH=True)
+		if rect:
+			return rect
+
+	rect = _rectFromObject(obj)
+	if rect:
+		return rect
+
+	words = _getObjectValue(obj, "words", "Words")
+	try:
+		wordIterator = iter(words or ())
+	except Exception:
+		wordIterator = ()
+	wordRects = []
+	for word in wordIterator:
+		rect = _extractRectLike(word)
+		if rect:
+			wordRects.append(rect)
+	if wordRects:
+		return (
+			min(rect[0] for rect in wordRects),
+			min(rect[1] for rect in wordRects),
+			max(rect[2] for rect in wordRects),
+			max(rect[3] for rect in wordRects),
+		)
 
 	return None
 
@@ -173,6 +258,87 @@ def _normalizeMenuRowRects(
 	return normalized
 
 
+_KNOWN_100_PERCENT_ROW_LAYOUT = (
+	("關閉提醒", 0),
+	("邀請", 1),
+	("相簿", 2),
+	("照片・影片", 3),
+	("檔案", 4),
+	("連結", 5),
+	("投票", 6),
+	("儲存聊天", 7),
+	("背景設定", 8),
+	("檢舉", 9),
+	("封鎖", 10),
+)
+_KNOWN_100_PERCENT_ROW_INDEX_BY_LABEL = dict(_KNOWN_100_PERCENT_ROW_LAYOUT)
+_REMINDER_TOGGLE_LABELS = {"開啟提醒", "關閉提醒"}
+for _label in _REMINDER_TOGGLE_LABELS:
+	_KNOWN_100_PERCENT_ROW_INDEX_BY_LABEL[_label] = 0
+_KNOWN_100_PERCENT_ANCHOR_LABELS = {
+	"投票",
+	"儲存聊天",
+	"背景設定",
+	"檢舉",
+	"封鎖",
+}
+
+
+def _inferKnownMenuRowIndex(
+	label: str | None,
+	rowRects: list[tuple[int, int, int, int]],
+) -> int | None:
+	# At 100% LINE exposes an extra row-like separator between 投票 and 儲存聊天.
+	if len(rowRects) != 12:
+		return None
+	return _KNOWN_100_PERCENT_ROW_INDEX_BY_LABEL.get(label or "")
+
+
+def _buildKnown100PercentLayoutElements(
+	rowRects: list[tuple[int, int, int, int]],
+	detectedElements: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+	if len(rowRects) != 12:
+		return []
+
+	detectedReminderLabel = next(
+		(
+			element.get("name")
+			for element in detectedElements or []
+			if element.get("name") in _REMINDER_TOGGLE_LABELS
+		),
+		None,
+	)
+	elements: list[dict[str, Any]] = []
+	for label, rowIndex in _KNOWN_100_PERCENT_ROW_LAYOUT:
+		if rowIndex >= len(rowRects):
+			continue
+		if rowIndex == 0 and detectedReminderLabel:
+			label = detectedReminderLabel
+		rowLeft, rowTop, rowRight, rowBottom = rowRects[rowIndex]
+		elements.append(
+			{
+				"name": label,
+				"role": None,
+				"clickPoint": (
+					int((rowLeft + rowRight) / 2),
+					int((rowTop + rowBottom) / 2),
+				),
+			},
+		)
+	return elements
+
+
+def _shouldUseKnown100PercentLayout(
+	elements: list[dict[str, Any]],
+	rowRects: list[tuple[int, int, int, int]],
+) -> bool:
+	if len(rowRects) != 12 or len(elements) >= 8:
+		return False
+	labels = {element.get("name") for element in elements}
+	return len(labels & _KNOWN_100_PERCENT_ANCHOR_LABELS) >= 2
+
+
 def _assignRowRectsToElements(
 	elements: list[dict[str, Any]],
 	rowRects: list[tuple[int, int, int, int]],
@@ -199,6 +365,10 @@ def _assignRowRectsToElements(
 				if bestDistance is None or distance < bestDistance:
 					bestDistance = distance
 					chosenRowIndex = rowIndex
+		else:
+			knownRowIndex = _inferKnownMenuRowIndex(element.get("name"), rowRects)
+			if knownRowIndex is not None and currentRow <= knownRowIndex <= maxRowIndex:
+				chosenRowIndex = knownRowIndex
 
 		rowLeft, rowTop, rowRight, rowBottom = rowRects[chosenRowIndex]
 		element["clickPoint"] = (
@@ -253,6 +423,13 @@ def _buildMenuElements(
 		)
 
 	if elements:
+		knownLayoutElements = []
+		if _shouldUseKnown100PercentLayout(elements, rowRects):
+			knownLayoutElements = _buildKnown100PercentLayoutElements(rowRects, elements)
+		if knownLayoutElements:
+			log.debug("LINE: ChatMoreOptions using known 100% popup row layout")
+			return knownLayoutElements
+
 		_assignRowRectsToElements(elements, rowRects)
 		itemHeight = (bottom - top) / len(elements)
 		for index, element in enumerate(elements):

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2826,8 +2826,8 @@ def _getChatHeaderIconPointFromRect(screenRect, scale, iconIndex=0):
 	return (iconX, iconY)
 
 
-def _getChatHeaderIconPoint(hwnd, iconIndex=0):
-	"""Return a LINE chat header icon point in screen coordinates.
+def _getChatHeaderIconPointInfo(hwnd, iconIndex=0):
+	"""Return a LINE chat header icon point and source rect in screen coordinates.
 
 	Use the client area before the outer window frame so hidden resize borders
 	and DWM frame differences do not shift header clicks across DPI settings.
@@ -2853,7 +2853,17 @@ def _getChatHeaderIconPoint(hwnd, iconIndex=0):
 			f"LINE: chat header icon index={iconIndex} outside rect={contentRect}, "
 			f"source={rectSource}, dpiScale={scale:.2f}",
 		)
-	return point
+	if not point:
+		return None
+	return (point, contentRect)
+
+
+def _getChatHeaderIconPoint(hwnd, iconIndex=0):
+	"""Return a LINE chat header icon point in screen coordinates."""
+	iconInfo = _getChatHeaderIconPointInfo(hwnd, iconIndex=iconIndex)
+	if not iconInfo:
+		return None
+	return iconInfo[0]
 
 
 # Physical-pixel cap for the right edge of LINE's left sidebar (icons column +
@@ -6657,10 +6667,10 @@ class AppModule(appModuleHandler.AppModule):
 			log.debug("LINE: no foreground window for header click")
 			return None
 
-		iconPoint = _getChatHeaderIconPoint(hwnd, iconIndex=2)
-		contentRect = _getWindowClientScreenRect(hwnd) or _getWindowScreenRect(hwnd)
-		if not iconPoint or not contentRect:
+		iconInfo = _getChatHeaderIconPointInfo(hwnd, iconIndex=2)
+		if not iconInfo:
 			return None
+		iconPoint, contentRect = iconInfo
 
 		return (iconPoint[0], iconPoint[1], contentRect[2])
 

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2701,6 +2701,161 @@ def _getDpiScale(hwnd=None):
 	return scale
 
 
+_CHAT_HEADER_ICON_Y_BASE = 55
+_CHAT_HEADER_ICON_SPACING_BASE = 27
+_CHAT_HEADER_FIRST_ICON_OFFSET_BASE = 15
+
+
+def _scaleLineUiPixels(value, scale):
+	try:
+		scale = float(scale)
+	except Exception:
+		scale = 1.0
+	if scale <= 0:
+		scale = 1.0
+	return int(value * scale)
+
+
+def _rectTupleFromWinRect(rect):
+	try:
+		left = int(rect.left)
+		top = int(rect.top)
+		right = int(rect.right)
+		bottom = int(rect.bottom)
+	except Exception:
+		return None
+	if right <= left or bottom <= top:
+		return None
+	return (left, top, right, bottom)
+
+
+def _getWindowScreenRect(hwnd, ctypesModule=None):
+	"""Return a top-level window rectangle in screen coordinates.
+
+	Prefer DWM extended frame bounds when available because they are not affected
+	by the invisible resize border around Qt windows.
+	"""
+	if not hwnd:
+		return None
+	if ctypesModule is None:
+		ctypesModule = ctypes
+
+	try:
+		rect = ctypesModule.wintypes.RECT()
+		result = ctypesModule.windll.user32.GetWindowRect(hwnd, ctypesModule.byref(rect))
+		if result == 0:
+			return None
+		windowRect = _rectTupleFromWinRect(rect)
+	except Exception:
+		windowRect = None
+
+	try:
+		dwmapi = getattr(ctypesModule.windll, "dwmapi", None)
+		if dwmapi:
+			DWMWA_EXTENDED_FRAME_BOUNDS = 9
+			dwmRect = ctypesModule.wintypes.RECT()
+			hr = dwmapi.DwmGetWindowAttribute(
+				hwnd,
+				DWMWA_EXTENDED_FRAME_BOUNDS,
+				ctypesModule.byref(dwmRect),
+				ctypesModule.sizeof(dwmRect),
+			)
+			extendedRect = _rectTupleFromWinRect(dwmRect)
+			if hr == 0 and extendedRect:
+				return extendedRect
+	except Exception:
+		pass
+
+	return windowRect
+
+
+def _getWindowClientScreenRect(hwnd, ctypesModule=None):
+	"""Return a window client rectangle converted to screen coordinates."""
+	if not hwnd:
+		return None
+	if ctypesModule is None:
+		ctypesModule = ctypes
+
+	try:
+		clientRect = ctypesModule.wintypes.RECT()
+		result = ctypesModule.windll.user32.GetClientRect(hwnd, ctypesModule.byref(clientRect))
+		if result == 0:
+			return None
+		width = int(clientRect.right - clientRect.left)
+		height = int(clientRect.bottom - clientRect.top)
+		if width <= 0 or height <= 0:
+			return None
+
+		topLeft = ctypesModule.wintypes.POINT()
+		topLeft.x = 0
+		topLeft.y = 0
+		bottomRight = ctypesModule.wintypes.POINT()
+		bottomRight.x = width
+		bottomRight.y = height
+		if ctypesModule.windll.user32.ClientToScreen(hwnd, ctypesModule.byref(topLeft)) == 0:
+			return None
+		if ctypesModule.windll.user32.ClientToScreen(hwnd, ctypesModule.byref(bottomRight)) == 0:
+			return None
+		left = int(topLeft.x)
+		top = int(topLeft.y)
+		right = int(bottomRight.x)
+		bottom = int(bottomRight.y)
+		if right <= left or bottom <= top:
+			return None
+		return (left, top, right, bottom)
+	except Exception:
+		return None
+
+
+def _getChatHeaderIconPointFromRect(screenRect, scale, iconIndex=0):
+	try:
+		left, top, right, bottom = [int(value) for value in screenRect]
+		iconIndex = max(0, int(iconIndex))
+	except Exception:
+		return None
+	if right <= left or bottom <= top:
+		return None
+
+	iconY = top + _scaleLineUiPixels(_CHAT_HEADER_ICON_Y_BASE, scale)
+	iconSpacing = _scaleLineUiPixels(_CHAT_HEADER_ICON_SPACING_BASE, scale)
+	firstIconOffset = _scaleLineUiPixels(_CHAT_HEADER_FIRST_ICON_OFFSET_BASE, scale)
+	iconX = right - firstIconOffset - (iconIndex * iconSpacing)
+
+	if iconX < left or iconX > right or iconY < top or iconY > bottom:
+		return None
+	return (iconX, iconY)
+
+
+def _getChatHeaderIconPoint(hwnd, iconIndex=0):
+	"""Return a LINE chat header icon point in screen coordinates.
+
+	Use the client area before the outer window frame so hidden resize borders
+	and DWM frame differences do not shift header clicks across DPI settings.
+	"""
+	scale = _getDpiScale(hwnd)
+	contentRect = _getWindowClientScreenRect(hwnd)
+	rectSource = "client"
+	if not contentRect:
+		contentRect = _getWindowScreenRect(hwnd)
+		rectSource = "window"
+	if not contentRect:
+		log.debug("LINE: no window rectangle for chat header icon")
+		return None
+
+	point = _getChatHeaderIconPointFromRect(contentRect, scale, iconIndex=iconIndex)
+	if point:
+		log.info(
+			f"LINE: chat header icon index={iconIndex} at {point}, "
+			f"rect={contentRect}, source={rectSource}, dpiScale={scale:.2f}",
+		)
+	else:
+		log.warning(
+			f"LINE: chat header icon index={iconIndex} outside rect={contentRect}, "
+			f"source={rectSource}, dpiScale={scale:.2f}",
+		)
+	return point
+
+
 # Physical-pixel cap for the right edge of LINE's left sidebar (icons column +
 # chat list panel). Empirically, LINE renders the sidebar at a fixed physical
 # pixel width regardless of DPI scaling (a Qt quirk on Windows): observed at
@@ -6482,9 +6637,9 @@ class AppModule(appModuleHandler.AppModule):
 		"""Get the screen position of the phone icon in the LINE chat header.
 
 		LINE's Qt6 UI does not expose header toolbar buttons via UIA.
-		We use the window geometry to calculate where the icons are.
-		All pixel offsets are scaled by system DPI so positions adapt to
-		different display scaling settings (100%–300%).
+		We use the window client geometry to calculate where the icons are.
+		All pixel offsets are scaled by window DPI so positions adapt to
+		different display scaling settings.
 
 		The chat header has icons from right to left:
 		  Index 0: More options (⋮ three dots menu)
@@ -6496,71 +6651,18 @@ class AppModule(appModuleHandler.AppModule):
 			(phoneX, phoneY, winRight) tuple, or None if window not found.
 		"""
 		import ctypes
-		import ctypes.wintypes
 
 		hwnd = ctypes.windll.user32.GetForegroundWindow()
 		if not hwnd:
 			log.debug("LINE: no foreground window for header click")
 			return None
 
-		scale = _getDpiScale(hwnd)
-
-		# Get window rect — try DwmGetWindowAttribute first for
-		# accurate extended frame bounds (avoids DPI virtualization).
-		rect = ctypes.wintypes.RECT()
-		ctypes.windll.user32.GetWindowRect(hwnd, ctypes.byref(rect))
-		winLeft = rect.left
-		winTop = rect.top
-		winRight = rect.right
-		winWidth = winRight - winLeft
-
-		# Also try DWM extended frame bounds
-		dwmRect = ctypes.wintypes.RECT()
-		try:
-			DWMWA_EXTENDED_FRAME_BOUNDS = 9
-			hr = ctypes.windll.dwmapi.DwmGetWindowAttribute(
-				hwnd,
-				DWMWA_EXTENDED_FRAME_BOUNDS,
-				ctypes.byref(dwmRect),
-				ctypes.sizeof(dwmRect),
-			)
-			if hr == 0:
-				log.info(
-					f"LINE: DWM frame bounds=({dwmRect.left},{dwmRect.top},{dwmRect.right},{dwmRect.bottom})",
-				)
-				# Use DWM bounds if different (more accurate)
-				if dwmRect.right != rect.right or dwmRect.top != rect.top:
-					log.info("LINE: using DWM bounds instead of GetWindowRect")
-					winLeft = dwmRect.left
-					winTop = dwmRect.top
-					winRight = dwmRect.right
-					winWidth = winRight - winLeft
-		except Exception:
-			pass
-
-		log.info(
-			f"LINE: window rect=({winLeft},{winTop},{winRight},{rect.bottom}), "
-			f"width={winWidth}, dpiScale={scale:.2f}",
-		)
-
-		# Reference values at 96 DPI (100% scaling), scaled by DPI factor.
-		# Icon spacing ~27px at 96 DPI, first icon offset ~15px from right edge.
-		iconY = winTop + int(55 * scale)
-		iconSpacing = int(27 * scale)
-		firstIconOffset = int(15 * scale)
-		iconX = winRight - firstIconOffset - (2 * iconSpacing)
-
-		log.info(
-			f"LINE: header icon pos: iconX={iconX}, iconY={iconY}, "
-			f"spacing={iconSpacing}, offset={firstIconOffset}",
-		)
-
-		# Verify position is within window bounds
-		if iconX < winLeft or iconX > winRight:
-			log.warning(f"LINE: icon position {iconX} outside window bounds")
+		iconPoint = _getChatHeaderIconPoint(hwnd, iconIndex=2)
+		contentRect = _getWindowClientScreenRect(hwnd) or _getWindowScreenRect(hwnd)
+		if not iconPoint or not contentRect:
 			return None
 
-		return (iconX, iconY, winRight)
+		return (iconPoint[0], iconPoint[1], contentRect[2])
 
 	def _clickMoreOptionsButton(self):
 		"""Click the more options (⋮) button in the chat header.
@@ -6569,55 +6671,18 @@ class AppModule(appModuleHandler.AppModule):
 		Returns True if successful, False if window not found.
 		"""
 		import ctypes
-		import ctypes.wintypes
 
 		hwnd = ctypes.windll.user32.GetForegroundWindow()
 		if not hwnd:
 			log.debug("LINE: no foreground window for more options click")
 			return False
 
-		scale = _getDpiScale(hwnd)
-
-		# Get window rect
-		rect = ctypes.wintypes.RECT()
-		ctypes.windll.user32.GetWindowRect(hwnd, ctypes.byref(rect))
-		winLeft = rect.left
-		winTop = rect.top
-		winRight = rect.right
-
-		# Try DWM extended frame bounds for accuracy
-		dwmRect = ctypes.wintypes.RECT()
-		try:
-			DWMWA_EXTENDED_FRAME_BOUNDS = 9
-			hr = ctypes.windll.dwmapi.DwmGetWindowAttribute(
-				hwnd,
-				DWMWA_EXTENDED_FRAME_BOUNDS,
-				ctypes.byref(dwmRect),
-				ctypes.sizeof(dwmRect),
-			)
-			if hr == 0 and (dwmRect.right != rect.right or dwmRect.top != rect.top):
-				winLeft = dwmRect.left
-				winTop = dwmRect.top
-				winRight = dwmRect.right
-		except Exception:
-			pass
-
-		# Calculate more options button position (rightmost icon, index 0)
-		iconY = winTop + int(55 * scale)
-		firstIconOffset = int(15 * scale)
-		moreOptionsX = winRight - firstIconOffset
-
-		log.info(
-			f"LINE: clicking more options button at ({moreOptionsX}, {iconY}), dpiScale={scale:.2f}",
-		)
-
-		# Verify position is within window bounds
-		if moreOptionsX < winLeft or moreOptionsX > winRight:
-			log.warning(f"LINE: more options position {moreOptionsX} outside window bounds")
+		clickPoint = _getChatHeaderIconPoint(hwnd, iconIndex=0)
+		if not clickPoint:
 			return False
 
 		# Click the button
-		self._clickAtPosition(moreOptionsX, iconY, hwnd)
+		self._clickAtPosition(clickPoint[0], clickPoint[1], hwnd)
 
 		return True
 
@@ -7941,10 +8006,12 @@ class AppModule(appModuleHandler.AppModule):
 			):
 				return
 
-			wRect = wintypes.RECT()
-			ctypes.windll.user32.GetWindowRect(targetHwnd, ctypes.byref(wRect))
-			width = wRect.right - wRect.left
-			height = wRect.bottom - wRect.top
+			windowRect = _getWindowScreenRect(targetHwnd)
+			if not windowRect:
+				return
+			left, top, right, bottom = windowRect
+			width = right - left
+			height = bottom - top
 			if width < 50 or height < 100:
 				return
 
@@ -7954,10 +8021,10 @@ class AppModule(appModuleHandler.AppModule):
 			threadWindows.append(
 				{
 					"hwnd": targetHwnd,
-					"left": wRect.left,
-					"top": wRect.top,
-					"right": wRect.right,
-					"bottom": wRect.bottom,
+					"left": left,
+					"top": top,
+					"right": right,
+					"bottom": bottom,
 					"width": width,
 					"height": height,
 					"area": width * height,
@@ -7981,8 +8048,12 @@ class AppModule(appModuleHandler.AppModule):
 
 		mainWindow = max(threadWindows, key=lambda item: item["area"])
 		scale = _getDpiScale(mainWindow["hwnd"])
-		anchorX = mainWindow["right"] - int(15 * scale)
-		anchorY = mainWindow["top"] + int(55 * scale)
+		anchorPoint = _getChatHeaderIconPoint(mainWindow["hwnd"], iconIndex=0)
+		if anchorPoint:
+			anchorX, anchorY = anchorPoint
+		else:
+			anchorX = mainWindow["right"] - _scaleLineUiPixels(_CHAT_HEADER_FIRST_ICON_OFFSET_BASE, scale)
+			anchorY = mainWindow["top"] + _scaleLineUiPixels(_CHAT_HEADER_ICON_Y_BASE, scale)
 		mainArea = max(mainWindow["area"], 1)
 
 		def _distanceToRect(pointX, pointY, rectInfo):

--- a/tests/test_chat_more_options.py
+++ b/tests/test_chat_more_options.py
@@ -77,6 +77,30 @@ def test_match_menu_label_handles_known_ocr_variants():
 	assert chat_more_options._matchMenuLabel("llnedes") is None
 
 
+def test_extract_ocr_lines_uses_word_rects_when_line_rect_is_missing():
+	class _Word:
+		def __init__(self, left, top, width, height):
+			self.left = left
+			self.top = top
+			self.width = width
+			self.height = height
+
+	class _Line:
+		text = "儲存聊天"
+
+		def __init__(self):
+			self.words = [
+				_Word(760, 288, 42, 27),
+				_Word(805, 290, 38, 25),
+			]
+
+	result = types.SimpleNamespace(lines=[_Line()])
+
+	assert chat_more_options._extractOcrLines(result) == [
+		{"text": "儲存聊天", "rect": (760, 288, 843, 315)},
+	]
+
+
 def test_build_menu_elements_keeps_only_actionable_items_and_uses_line_rects():
 	lines = [
 		{"text": "5", "rect": (1070, 95, 1090, 118)},
@@ -164,6 +188,158 @@ def test_build_menu_elements_aligns_to_popup_row_rects_for_lower_items():
 		(1203, 523),
 		(1203, 572),
 	]
+
+
+def test_build_menu_elements_aligns_sparse_100_percent_ocr_to_known_row_layout():
+	lines = [
+		{"text": "關閉提醒", "rect": None},
+		{"text": "投票", "rect": None},
+		{"text": "儲存聊天", "rect": None},
+		{"text": "背景設定", "rect": None},
+	]
+	row_rects = [
+		(713, 77, 893, 104),
+		(713, 104, 893, 131),
+		(713, 142, 893, 169),
+		(713, 169, 893, 196),
+		(713, 196, 893, 223),
+		(713, 223, 893, 250),
+		(713, 250, 893, 277),
+		(713, 288, 893, 315),
+		(713, 326, 893, 353),
+		(713, 353, 893, 380),
+		(713, 380, 893, 407),
+		(713, 418, 893, 464),
+	]
+
+	elements = chat_more_options._buildMenuElements(
+		lines,
+		(703, 61, 903, 480),
+		rowRects=row_rects,
+	)
+
+	assert [element["name"] for element in elements] == [
+		"關閉提醒",
+		"邀請",
+		"相簿",
+		"照片・影片",
+		"檔案",
+		"連結",
+		"投票",
+		"儲存聊天",
+		"背景設定",
+		"檢舉",
+		"封鎖",
+	]
+	assert [element["clickPoint"] for element in elements] == [
+		(803, 90),
+		(803, 117),
+		(803, 155),
+		(803, 182),
+		(803, 209),
+		(803, 236),
+		(803, 263),
+		(803, 301),
+		(803, 339),
+		(803, 366),
+		(803, 393),
+	]
+
+
+def test_build_menu_elements_keeps_mute_toggle_in_sparse_scaled_known_layout():
+	lines = [
+		{"text": "關閉提醒", "rect": None},
+		{"text": "照片・影片", "rect": None},
+		{"text": "連結", "rect": None},
+		{"text": "儲存聊天", "rect": None},
+		{"text": "背景設定", "rect": None},
+		{"text": "檢舉", "rect": None},
+		{"text": "封鎖", "rect": None},
+	]
+	row_rects = [
+		(891, 95, 1116, 128),
+		(891, 128, 1116, 161),
+		(891, 176, 1116, 209),
+		(891, 210, 1116, 243),
+		(891, 243, 1116, 276),
+		(891, 277, 1116, 310),
+		(891, 311, 1116, 344),
+		(891, 358, 1116, 391),
+		(891, 406, 1116, 439),
+		(891, 440, 1116, 473),
+		(891, 473, 1116, 506),
+		(891, 521, 1116, 578),
+	]
+
+	elements = chat_more_options._buildMenuElements(
+		lines,
+		(879, 75, 1129, 599),
+		rowRects=row_rects,
+	)
+
+	assert [element["name"] for element in elements] == [
+		"關閉提醒",
+		"邀請",
+		"相簿",
+		"照片・影片",
+		"檔案",
+		"連結",
+		"投票",
+		"儲存聊天",
+		"背景設定",
+		"檢舉",
+		"封鎖",
+	]
+	assert elements[0]["clickPoint"] == (1003, 111)
+	assert elements[-1]["clickPoint"] == (1003, 489)
+
+
+def test_build_menu_elements_keeps_unmute_toggle_in_sparse_scaled_known_layout():
+	lines = [
+		{"text": "開啟提醒", "rect": None},
+		{"text": "照片・影片", "rect": None},
+		{"text": "連結", "rect": None},
+		{"text": "儲存聊天", "rect": None},
+		{"text": "背景設定", "rect": None},
+		{"text": "檢舉", "rect": None},
+		{"text": "封鎖", "rect": None},
+	]
+	row_rects = [
+		(891, 95, 1116, 128),
+		(891, 128, 1116, 161),
+		(891, 176, 1116, 209),
+		(891, 210, 1116, 243),
+		(891, 243, 1116, 276),
+		(891, 277, 1116, 310),
+		(891, 311, 1116, 344),
+		(891, 358, 1116, 391),
+		(891, 406, 1116, 439),
+		(891, 440, 1116, 473),
+		(891, 473, 1116, 506),
+		(891, 521, 1116, 578),
+	]
+
+	elements = chat_more_options._buildMenuElements(
+		lines,
+		(879, 75, 1129, 599),
+		rowRects=row_rects,
+	)
+
+	assert [element["name"] for element in elements] == [
+		"開啟提醒",
+		"邀請",
+		"相簿",
+		"照片・影片",
+		"檔案",
+		"連結",
+		"投票",
+		"儲存聊天",
+		"背景設定",
+		"檢舉",
+		"封鎖",
+	]
+	assert elements[0]["clickPoint"] == (1003, 111)
+	assert elements[-1]["clickPoint"] == (1003, 489)
 
 
 def test_chat_more_options_click_invokes_action_callback_and_closes_window():

--- a/tests/test_line_resource_guards.py
+++ b/tests/test_line_resource_guards.py
@@ -147,13 +147,19 @@ def test_chat_header_icon_point_prefers_client_rect_over_outer_frame():
 			"_CHAT_HEADER_ICON_SPACING_BASE",
 			"_CHAT_HEADER_FIRST_ICON_OFFSET_BASE",
 		},
-		function_names={"_scaleLineUiPixels", "_getChatHeaderIconPointFromRect", "_getChatHeaderIconPoint"},
+		function_names={
+			"_scaleLineUiPixels",
+			"_getChatHeaderIconPointFromRect",
+			"_getChatHeaderIconPointInfo",
+			"_getChatHeaderIconPoint",
+		},
 		namespace={"log": _Log()},
 	)
 	ns["_getDpiScale"] = lambda _hwnd: 1.5
 	ns["_getWindowClientScreenRect"] = lambda _hwnd: (12, 34, 1912, 1074)
 	ns["_getWindowScreenRect"] = lambda _hwnd: (0, 0, 1920, 1080)
 
+	assert ns["_getChatHeaderIconPointInfo"](101, iconIndex=0) == ((1890, 116), (12, 34, 1912, 1074))
 	assert ns["_getChatHeaderIconPoint"](101, iconIndex=0) == (1890, 116)
 
 

--- a/tests/test_line_resource_guards.py
+++ b/tests/test_line_resource_guards.py
@@ -49,6 +49,114 @@ class _Log:
 		pass
 
 
+def test_window_client_screen_rect_converts_client_area_to_screen_coordinates():
+	class _Rect:
+		left = 0
+		top = 0
+		right = 1280
+		bottom = 720
+
+	class _Point:
+		def __init__(self):
+			self.x = 0
+			self.y = 0
+
+	def _get_client_rect(_hwnd, rect):
+		rect.left = 0
+		rect.top = 0
+		rect.right = 1280
+		rect.bottom = 720
+		return 1
+
+	def _client_to_screen(_hwnd, point):
+		point.x += 320
+		point.y += 180
+		return 1
+
+	user32 = SimpleNamespace(
+		GetClientRect=_get_client_rect,
+		ClientToScreen=_client_to_screen,
+	)
+	ctypes_module = SimpleNamespace(
+		windll=SimpleNamespace(user32=user32),
+		wintypes=SimpleNamespace(RECT=_Rect, POINT=_Point),
+		byref=lambda value: value,
+	)
+	ns = _load_line_symbols(function_names={"_getWindowClientScreenRect"})
+
+	assert ns["_getWindowClientScreenRect"](101, ctypesModule=ctypes_module) == (320, 180, 1600, 900)
+
+
+def test_window_screen_rect_prefers_dwm_extended_frame_bounds():
+	class _Rect:
+		def __init__(self):
+			self.left = 0
+			self.top = 0
+			self.right = 0
+			self.bottom = 0
+
+	def _get_window_rect(_hwnd, rect):
+		rect.left = 10
+		rect.top = 20
+		rect.right = 1300
+		rect.bottom = 760
+		return 1
+
+	def _dwm_get_window_attribute(_hwnd, _attr, rect, _size):
+		rect.left = 18
+		rect.top = 28
+		rect.right = 1292
+		rect.bottom = 752
+		return 0
+
+	ctypes_module = SimpleNamespace(
+		windll=SimpleNamespace(
+			user32=SimpleNamespace(GetWindowRect=_get_window_rect),
+			dwmapi=SimpleNamespace(DwmGetWindowAttribute=_dwm_get_window_attribute),
+		),
+		wintypes=SimpleNamespace(RECT=_Rect),
+		byref=lambda value: value,
+		sizeof=lambda _value: 16,
+	)
+	ns = _load_line_symbols(function_names={"_rectTupleFromWinRect", "_getWindowScreenRect"})
+
+	assert ns["_getWindowScreenRect"](101, ctypesModule=ctypes_module) == (18, 28, 1292, 752)
+
+
+def test_chat_header_icon_point_scales_from_client_rect_for_common_dpi_values():
+	ns = _load_line_symbols(
+		assignment_names={
+			"_CHAT_HEADER_ICON_Y_BASE",
+			"_CHAT_HEADER_ICON_SPACING_BASE",
+			"_CHAT_HEADER_FIRST_ICON_OFFSET_BASE",
+		},
+		function_names={"_scaleLineUiPixels", "_getChatHeaderIconPointFromRect"},
+	)
+	rect = (100, 50, 2020, 1130)
+
+	assert ns["_getChatHeaderIconPointFromRect"](rect, 1.0, iconIndex=0) == (2005, 105)
+	assert ns["_getChatHeaderIconPointFromRect"](rect, 1.5, iconIndex=0) == (1998, 132)
+	assert ns["_getChatHeaderIconPointFromRect"](rect, 2.0, iconIndex=0) == (1990, 160)
+	assert ns["_getChatHeaderIconPointFromRect"](rect, 1.5, iconIndex=2) == (1918, 132)
+
+
+def test_chat_header_icon_point_prefers_client_rect_over_outer_frame():
+	ns = _load_line_symbols(
+		assignment_names={
+			"_CHAT_HEADER_ICON_Y_BASE",
+			"_CHAT_HEADER_ICON_SPACING_BASE",
+			"_CHAT_HEADER_FIRST_ICON_OFFSET_BASE",
+		},
+		function_names={"_scaleLineUiPixels", "_getChatHeaderIconPointFromRect", "_getChatHeaderIconPoint"},
+		namespace={"log": _Log()},
+	)
+	ns["_getDpiScale"] = lambda _hwnd: 1.5
+	ns["_getWindowClientScreenRect"] = lambda _hwnd: (12, 34, 1912, 1074)
+	ns["_getWindowScreenRect"] = lambda _hwnd: (0, 0, 1920, 1080)
+
+	assert ns["_getChatHeaderIconPoint"](101, iconIndex=0) == (1890, 116)
+
+
 def test_notes_window_context_uses_only_fresh_cache():
 	ns = _load_line_symbols(
 		assignment_names={


### PR DESCRIPTION
## Summary
- Preserve the actual reminder toggle label in the 100%/125% fallback layout so `開啟提醒` and `關閉提醒` both stay visible and clickable.
- Keep the fixed 12-row popup geometry for sparse OCR cases, but let the first row adopt the OCR-detected reminder state instead of hard-coding `關閉提醒`.
- Add regression coverage for both reminder states at the scaled popup layout.

## Testing
- Syntax check passed.
- `chatMoreOptions` tests passed, including the new 125% reminder-state cases.
- Related LINE resource-guard tests passed.
- `ruff` passed and `git diff --check` passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 修復兩個問題：(1) 在 100%/125% DPI 的稀疏 OCR 情境下，提醒切換按鈕的標籤（`開啟提醒`/`關閉提醒`）會被動態保留，而非固定寫死為 `關閉提醒`；(2) 將聊天標題列圖示座標計算重構為使用 client 矩形（優先）搭配 DWM 擴展邊框，消除 DPI 縮放時的偏移。新增的測試涵蓋兩種提醒狀態以及 client 矩形轉換。

<h3>Confidence Score: 5/5</h3>

此 PR 可安全合併，修復清晰且有完整測試覆蓋

未發現 P0 或 P1 問題；核心修復（動態提醒標籤）邏輯正確，重構後的圖示座標輔助函式有對應的單元測試驗證

無需特別關注的檔案

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/appModules/_virtualWindows/chatMoreOptions.py | 新增 `_buildKnown100PercentLayoutElements`、`_shouldUseKnown100PercentLayout` 等函式，以動態偵測提醒狀態並在稀疏 OCR 情境下套用已知列版面；同時大幅重構 `_extractRectLike` 以支援更多矩形格式 |
| addon/appModules/line.py | 將散落於 `_getPhoneIconHeaderPos` 與 `_clickMoreOptionsButton` 的重複視窗矩形與圖示位置計算，重構為共用的 `_getWindowScreenRect`、`_getWindowClientScreenRect`、`_getChatHeaderIconPointFromRect` 等輔助函式 |
| tests/test_chat_more_options.py | 新增三個測試案例：word-level 矩形合併、`關閉提醒` 及 `開啟提醒` 在 125% DPI 稀疏版面中的正確映射 |
| tests/test_line_resource_guards.py | 新增四個單元測試驗證 client 矩形轉換、DWM 擴展邊框優先、不同 DPI 縮放的圖示位置計算，以及優先使用 client 矩形的邏輯 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OCR 偵測選單列] --> B{rowRects == 12?}
    B -- 否 --> C[標準 _assignRowRectsToElements]
    B -- 是 --> D{elements < 8 且錨點標籤 >= 2?}
    D -- 否 --> C
    D -- 是 --> E[_buildKnown100PercentLayoutElements]
    E --> F{detectedElements 含提醒標籤?}
    F -- 是 --> G[rowIndex 0 套用偵測到的標籤 開啟提醒 或 關閉提醒]
    F -- 否 --> H[rowIndex 0 保留預設 關閉提醒]
    G --> I[回傳 11 個已知版面元素]
    H --> I
    C --> J[依 Y 座標或已知列索引對齊]
    J --> K[回傳對齊後的元素]

    subgraph 圖示座標計算
        L[_getChatHeaderIconPointInfo] --> M[_getWindowClientScreenRect]
        M -- 失敗 --> N[_getWindowScreenRect / DWM]
        M -- 成功 --> O[_getChatHeaderIconPointFromRect 以 client rect 計算]
        N --> O
        O --> P[回傳 iconPoint + contentRect]
    end
```

<sub>Reviews (2): Last reviewed commit: ["Fix LINE more options layout and header ..."](https://github.com/keyang556/linedesktopnvda/commit/7cd903f222ac6500431a4514a52316790c7f5326) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30595412)</sub>

<!-- /greptile_comment -->