### PR TITLE
Add Pollinations.AI image description + global max-tokens + language-aware default prompt

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2019,7 +2019,9 @@ _IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB = (
 )
 _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_KEY_BLOB = "oLtfHW4hFhTMLQ0mKKcEqd70nU8Z9EsEjjSKfueLCUCnJD9oee2CTd3GtTi0LyS6ZJMuee/jIxFiXDH9kzdyFOMVRfIjMRxJzqZxnccS+p5B1gjbWxYyMLY="
 _IMAGE_DESCRIPTION_NVIDIA_DEFAULT_KEY_BLOB = "z4L9t8i44kXzffkss7ukUYezYDRvTRxxgKURaLeyOl2Ea8kLN4dNweWybeuf4F8SD6I8ArEWqbvry5BB2o4MxerrJgd0OZD8pQNm9Nw6P7RE2mDI1xktlM4bj6XpwU9G/0wFnMMn"
-_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_KEY_BLOB = "9djyxTd4B3//wSRROFV/x5bpuusesK71/tOYdrtn4jf6YeRcniZVExF4//O0M+0G61hO0fkmB99ToQl9b3awbnwgPw=="
+_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_KEY_BLOB = (
+	"9djyxTd4B3//wSRROFV/x5bpuusesK71/tOYdrtn4jf6YeRcniZVExF4//O0M+0G61hO0fkmB99ToQl9b3awbnwgPw=="
+)
 _IMAGE_DESCRIPTION_USER_KEY_FILENAME = "line_desktop_image_api_key.dat"
 _IMAGE_DESCRIPTION_USER_OLLAMA_KEY_FILENAME = "line_desktop_ollama_api_key.dat"
 _IMAGE_DESCRIPTION_USER_NVIDIA_KEY_FILENAME = "line_desktop_nvidia_api_key.dat"
@@ -2989,9 +2991,7 @@ def _getEffectiveImageMaxTokens():
 	"""Return the cached max-tokens value; lazily resolved from disk on first call."""
 	global _cachedEffectiveImageMaxTokens
 	if _cachedEffectiveImageMaxTokens is _NOT_COMPUTED:
-		_cachedEffectiveImageMaxTokens = (
-			getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
-		)
+		_cachedEffectiveImageMaxTokens = getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
 	return _cachedEffectiveImageMaxTokens
 
 

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -3172,10 +3172,10 @@ def _callGoogleImageDescriptionApi(contents, timeout=30.0):
 			model=_getEffectiveImageModel(),
 			key=apiKey,
 		)
-		body = {
-			"contents": contents,
-			"generationConfig": {"maxOutputTokens": _getEffectiveImageMaxTokens()},
-		}
+		body = {"contents": contents}
+		_userMaxTokens = getUserImageMaxTokens()
+		if _userMaxTokens is not None:
+			body["generationConfig"] = {"maxOutputTokens": _userMaxTokens}
 		req = urllib.request.Request(
 			url,
 			data=json.dumps(body).encode("utf-8"),

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -1988,16 +1988,19 @@ _suppressAddon = False
 _IMAGE_DESCRIPTION_PROVIDER_GOOGLE = "google"
 _IMAGE_DESCRIPTION_PROVIDER_OLLAMA = "ollama"
 _IMAGE_DESCRIPTION_PROVIDER_NVIDIA = "nvidia"
+_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS = "pollinations"
 _IMAGE_DESCRIPTION_AVAILABLE_PROVIDERS = (
 	_IMAGE_DESCRIPTION_PROVIDER_GOOGLE,
 	_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
 	_IMAGE_DESCRIPTION_PROVIDER_NVIDIA,
+	_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS,
 )
 _IMAGE_DESCRIPTION_DEFAULT_PROVIDER = _IMAGE_DESCRIPTION_PROVIDER_GOOGLE
 _IMAGE_DESCRIPTION_PROVIDER_LABELS = {
 	_IMAGE_DESCRIPTION_PROVIDER_GOOGLE: "Google AI",
 	_IMAGE_DESCRIPTION_PROVIDER_OLLAMA: "Ollama Cloud",
 	_IMAGE_DESCRIPTION_PROVIDER_NVIDIA: "NVIDIA NIM",
+	_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS: "Pollinations.AI",
 }
 _IMAGE_DESCRIPTION_USER_PROVIDER_FILENAME = "line_desktop_image_provider.txt"
 
@@ -2016,13 +2019,17 @@ _IMAGE_DESCRIPTION_DEFAULT_KEY_BLOB = (
 )
 _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_KEY_BLOB = "oLtfHW4hFhTMLQ0mKKcEqd70nU8Z9EsEjjSKfueLCUCnJD9oee2CTd3GtTi0LyS6ZJMuee/jIxFiXDH9kzdyFOMVRfIjMRxJzqZxnccS+p5B1gjbWxYyMLY="
 _IMAGE_DESCRIPTION_NVIDIA_DEFAULT_KEY_BLOB = "z4L9t8i44kXzffkss7ukUYezYDRvTRxxgKURaLeyOl2Ea8kLN4dNweWybeuf4F8SD6I8ArEWqbvry5BB2o4MxerrJgd0OZD8pQNm9Nw6P7RE2mDI1xktlM4bj6XpwU9G/0wFnMMn"
+_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_KEY_BLOB = "9djyxTd4B3//wSRROFV/x5bpuusesK71/tOYdrtn4jf6YeRcniZVExF4//O0M+0G61hO0fkmB99ToQl9b3awbnwgPw=="
 _IMAGE_DESCRIPTION_USER_KEY_FILENAME = "line_desktop_image_api_key.dat"
 _IMAGE_DESCRIPTION_USER_OLLAMA_KEY_FILENAME = "line_desktop_ollama_api_key.dat"
 _IMAGE_DESCRIPTION_USER_NVIDIA_KEY_FILENAME = "line_desktop_nvidia_api_key.dat"
+_IMAGE_DESCRIPTION_USER_POLLINATIONS_KEY_FILENAME = "line_desktop_pollinations_api_key.dat"
 _IMAGE_DESCRIPTION_USER_MODEL_FILENAME = "line_desktop_image_model.txt"
 _IMAGE_DESCRIPTION_USER_OLLAMA_MODEL_FILENAME = "line_desktop_ollama_model.txt"
 _IMAGE_DESCRIPTION_USER_NVIDIA_MODEL_FILENAME = "line_desktop_nvidia_model.txt"
+_IMAGE_DESCRIPTION_USER_POLLINATIONS_MODEL_FILENAME = "line_desktop_pollinations_model.txt"
 _IMAGE_DESCRIPTION_USER_PROMPT_FILENAME = "line_desktop_image_prompt.txt"
+_IMAGE_DESCRIPTION_USER_MAX_TOKENS_FILENAME = "line_desktop_image_max_tokens.txt"
 # Default Google model used when the user has not picked one in the settings panel.
 _IMAGE_DESCRIPTION_DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
 # Default Ollama Cloud model used when the user has not picked one in the settings panel.
@@ -2066,15 +2073,41 @@ _IMAGE_DESCRIPTION_NVIDIA_AVAILABLE_MODELS = (
 	"qwen/qwen3.5-122b-a10b",
 	"qwen/qwen3.5-397b-a17b",
 )
+# Default Pollinations.AI model used when the user has not picked one.
+_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL = "openai"
+# Vision-capable Pollinations.AI models. Strings are the actual model IDs sent
+# to the API; the user-facing labels live in _IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS.
+_IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS = (
+	"claude-fast",
+	"openai",
+	"openai-fast",
+	"openai-large",
+)
+# Display labels for Pollinations.AI models, surfaced in the settings dropdown.
+_IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS = {
+	"claude-fast": "Claude Haiku 4.5",
+	"openai": "GPT-5.4 Nano",
+	"openai-fast": "GPT-5 Nano",
+	"openai-large": "GPT-5.4",
+}
 _IMAGE_DESCRIPTION_ENDPOINT = (
 	"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
 )
 _IMAGE_DESCRIPTION_OLLAMA_ENDPOINT = "https://ollama.com/api/chat"
 _IMAGE_DESCRIPTION_NVIDIA_ENDPOINT = "https://integrate.api.nvidia.com/v1/chat/completions"
-_IMAGE_DESCRIPTION_DEFAULT_PROMPT = "請用繁體中文簡要描述這張圖片的內容。"
+_IMAGE_DESCRIPTION_POLLINATIONS_ENDPOINT = "https://gen.pollinations.ai/v1/chat/completions"
+_IMAGE_DESCRIPTION_DEFAULT_PROMPT = (
+	"Describe this image succinctly, but in as much detail as possible. "
+	"If there is text, ensure it is included in your response exactly as shown."
+)
 # Maximum length accepted from user-supplied prompts, to avoid pathological
 # payloads being sent to the API.
 _IMAGE_DESCRIPTION_PROMPT_MAX_LEN = 2000
+# User-configurable max output tokens used by every backend that accepts the
+# parameter. Bounded so the user cannot accidentally send pathological values.
+_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS = 700
+_IMAGE_DESCRIPTION_MIN_MAX_TOKENS = 50
+_IMAGE_DESCRIPTION_MAX_MAX_TOKENS = 4000
 
 _IMAGE_API_KEY_SALT_LEN = 16
 _IMAGE_API_KEY_MAC_LEN = 16
@@ -2087,9 +2120,12 @@ _NOT_COMPUTED = object()
 _cachedEffectiveImageApiKey = _NOT_COMPUTED
 _cachedEffectiveOllamaApiKey = _NOT_COMPUTED
 _cachedEffectiveNvidiaApiKey = _NOT_COMPUTED
+_cachedEffectivePollinationsApiKey = _NOT_COMPUTED
 _cachedEffectiveImageProvider = _NOT_COMPUTED
 _cachedEffectiveOllamaModel = _NOT_COMPUTED
 _cachedEffectiveNvidiaModel = _NOT_COMPUTED
+_cachedEffectivePollinationsModel = _NOT_COMPUTED
+_cachedEffectiveImageMaxTokens = _NOT_COMPUTED
 
 
 def _deriveImageApiKeyMaterial(salt, length):
@@ -2347,6 +2383,73 @@ def _getEffectiveNvidiaApiKey():
 	if _cachedEffectiveNvidiaApiKey is _NOT_COMPUTED:
 		_initEffectiveNvidiaApiKey()
 	return _cachedEffectiveNvidiaApiKey
+
+
+def _getPollinationsApiKeyStorePath():
+	"""Return the filesystem path for the user-supplied Pollinations.AI API key file."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_POLLINATIONS_KEY_FILENAME)
+
+
+def getUserPollinationsApiKey():
+	"""Return the plain Pollinations.AI API key previously set by the user, or None."""
+	path = _getPollinationsApiKeyStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			blob = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user Pollinations API key: {e}", exc_info=True)
+		return None
+	return _deobfuscateImageApiKey(blob)
+
+
+def setUserPollinationsApiKey(plain):
+	"""Persist a user-supplied Pollinations.AI API key (obfuscated). Empty/None clears it."""
+	global _cachedEffectivePollinationsApiKey
+	path = _getPollinationsApiKeyStorePath()
+	if not path:
+		return False
+	try:
+		if not plain:
+			if os.path.isfile(path):
+				os.remove(path)
+			_cachedEffectivePollinationsApiKey = _deobfuscateImageApiKey(
+				_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_KEY_BLOB,
+			)
+		else:
+			blob = _obfuscateImageApiKey(plain)
+			with open(path, "w", encoding="utf-8") as f:
+				f.write(blob)
+			_cachedEffectivePollinationsApiKey = plain
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user Pollinations API key: {e}", exc_info=True)
+		return False
+
+
+def _initEffectivePollinationsApiKey():
+	"""Decrypt and cache the effective Pollinations.AI API key."""
+	global _cachedEffectivePollinationsApiKey
+	userKey = getUserPollinationsApiKey()
+	_cachedEffectivePollinationsApiKey = userKey or _deobfuscateImageApiKey(
+		_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_KEY_BLOB,
+	)
+
+
+def _getEffectivePollinationsApiKey():
+	"""Return the cached Pollinations.AI API key; falls back to lazy init if not yet computed."""
+	if _cachedEffectivePollinationsApiKey is _NOT_COMPUTED:
+		_initEffectivePollinationsApiKey()
+	return _cachedEffectivePollinationsApiKey
 
 
 def _getImageProviderStorePath():
@@ -2608,6 +2711,72 @@ def _getEffectiveNvidiaModel():
 	return _cachedEffectiveNvidiaModel
 
 
+def _getPollinationsModelStorePath():
+	"""Return the filesystem path for the user-selected Pollinations.AI model preference."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_POLLINATIONS_MODEL_FILENAME)
+
+
+def getUserPollinationsModel():
+	"""Return the Pollinations.AI model ID previously chosen by the user, or None."""
+	path = _getPollinationsModelStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			value = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user Pollinations model: {e}", exc_info=True)
+		return None
+	if not value:
+		return None
+	if value not in _IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS:
+		log.debug(f"LINE: stored Pollinations model {value!r} is not in the allowed list")
+		return None
+	return value
+
+
+def setUserPollinationsModel(name):
+	"""Persist a user-selected Pollinations.AI model. Empty/None or default clears the file."""
+	global _cachedEffectivePollinationsModel
+	path = _getPollinationsModelStorePath()
+	if not path:
+		return False
+	try:
+		if not name or name == _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL:
+			if os.path.isfile(path):
+				os.remove(path)
+			_cachedEffectivePollinationsModel = _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL
+			return True
+		if name not in _IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS:
+			log.warning(f"LINE: refusing to save unknown Pollinations model {name!r}")
+			return False
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(name)
+		_cachedEffectivePollinationsModel = name
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user Pollinations model: {e}", exc_info=True)
+		return False
+
+
+def _getEffectivePollinationsModel():
+	"""Return the cached Pollinations.AI model ID; lazily resolved from disk on first call."""
+	global _cachedEffectivePollinationsModel
+	if _cachedEffectivePollinationsModel is _NOT_COMPUTED:
+		_cachedEffectivePollinationsModel = (
+			getUserPollinationsModel() or _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL
+		)
+	return _cachedEffectivePollinationsModel
+
+
 def _getImagePromptStorePath():
 	"""Return the filesystem path for the user-supplied description prompt."""
 	try:
@@ -2671,6 +2840,159 @@ def _getEffectiveImagePrompt():
 	if _cachedEffectiveImagePrompt is _NOT_COMPUTED:
 		_cachedEffectiveImagePrompt = getUserImagePrompt() or _IMAGE_DESCRIPTION_DEFAULT_PROMPT
 	return _cachedEffectiveImagePrompt
+
+
+def _nvdaLanguageHint():
+	"""Map NVDA's UI language to an English language name for the AI prompt.
+
+	NVDA's languageHandler returns codes like ``zh_TW`` or ``ja``; we translate
+	those into a phrase the AI service can recognise and use to choose its
+	output language. Returns None when the language is English or unknown so
+	the caller can skip appending a hint.
+	"""
+	try:
+		import languageHandler
+
+		lang = (languageHandler.getLanguage() or "").strip()
+	except Exception:
+		return None
+	if not lang:
+		return None
+	normalised = lang.replace("-", "_").split(".", 1)[0].lower()
+	# Exact match takes precedence so traditional/simplified Chinese variants
+	# do not collapse onto a single label.
+	exactMap = {
+		"zh_tw": "Chinese Traditional",
+		"zh_hk": "Chinese Traditional",
+		"zh_mo": "Chinese Traditional",
+		"zh_cn": "Chinese Simplified",
+		"zh_sg": "Chinese Simplified",
+		"zh_hans": "Chinese Simplified",
+		"zh_hant": "Chinese Traditional",
+		"pt_br": "Brazilian Portuguese",
+	}
+	if normalised in exactMap:
+		return exactMap[normalised]
+	base = normalised.split("_", 1)[0]
+	baseMap = {
+		"en": None,
+		"zh": "Chinese Simplified",
+		"ja": "Japanese",
+		"ko": "Korean",
+		"th": "Thai",
+		"vi": "Vietnamese",
+		"id": "Indonesian",
+		"ms": "Malay",
+		"es": "Spanish",
+		"fr": "French",
+		"de": "German",
+		"it": "Italian",
+		"pt": "Portuguese",
+		"ru": "Russian",
+		"ar": "Arabic",
+		"tr": "Turkish",
+		"nl": "Dutch",
+		"pl": "Polish",
+		"sv": "Swedish",
+		"fi": "Finnish",
+		"da": "Danish",
+		"no": "Norwegian",
+		"cs": "Czech",
+		"hu": "Hungarian",
+		"el": "Greek",
+		"he": "Hebrew",
+		"hi": "Hindi",
+	}
+	return baseMap.get(base)
+
+
+def _getRuntimeImagePrompt():
+	"""Return the prompt actually sent to the API, with a language hint when applicable."""
+	base = _getEffectiveImagePrompt()
+	# Language hint is appended only for the default prompt; custom prompts are
+	# left untouched so the user can pick their own output language.
+	if base != _IMAGE_DESCRIPTION_DEFAULT_PROMPT:
+		return base
+	hint = _nvdaLanguageHint()
+	if not hint:
+		return base
+	return f"{base} Respond in {hint}."
+
+
+def _getImageMaxTokensStorePath():
+	"""Return the filesystem path for the user-configured max-tokens value."""
+	try:
+		import globalVars
+
+		configPath = globalVars.appArgs.configPath
+	except Exception:
+		return None
+	if not configPath:
+		return None
+	return os.path.join(configPath, _IMAGE_DESCRIPTION_USER_MAX_TOKENS_FILENAME)
+
+
+def getUserImageMaxTokens():
+	"""Return the user-configured max output tokens, or None when unset."""
+	path = _getImageMaxTokensStorePath()
+	if not path or not os.path.isfile(path):
+		return None
+	try:
+		with open(path, "r", encoding="utf-8") as f:
+			value = f.read().strip()
+	except Exception as e:
+		log.debug(f"LINE: failed to read user image max tokens: {e}", exc_info=True)
+		return None
+	if not value:
+		return None
+	try:
+		n = int(value)
+	except ValueError:
+		log.debug(f"LINE: stored image max tokens {value!r} is not an integer")
+		return None
+	if n < _IMAGE_DESCRIPTION_MIN_MAX_TOKENS or n > _IMAGE_DESCRIPTION_MAX_MAX_TOKENS:
+		log.debug(f"LINE: stored image max tokens {n} is out of range")
+		return None
+	return n
+
+
+def setUserImageMaxTokens(value):
+	"""Persist a user-configured max-tokens value. None or default clears the file."""
+	global _cachedEffectiveImageMaxTokens
+	path = _getImageMaxTokensStorePath()
+	if not path:
+		return False
+	try:
+		if value is None or value == _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS:
+			if os.path.isfile(path):
+				os.remove(path)
+			_cachedEffectiveImageMaxTokens = _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+			return True
+		try:
+			n = int(value)
+		except (TypeError, ValueError):
+			log.warning(f"LINE: refusing to save non-integer max tokens {value!r}")
+			return False
+		if n < _IMAGE_DESCRIPTION_MIN_MAX_TOKENS or n > _IMAGE_DESCRIPTION_MAX_MAX_TOKENS:
+			log.warning(f"LINE: refusing to save out-of-range max tokens {n}")
+			return False
+		with open(path, "w", encoding="utf-8") as f:
+			f.write(str(n))
+		_cachedEffectiveImageMaxTokens = n
+		return True
+	except Exception as e:
+		log.warning(f"LINE: failed to save user image max tokens: {e}", exc_info=True)
+		return False
+
+
+def _getEffectiveImageMaxTokens():
+	"""Return the cached max-tokens value; lazily resolved from disk on first call."""
+	global _cachedEffectiveImageMaxTokens
+	if _cachedEffectiveImageMaxTokens is _NOT_COMPUTED:
+		_cachedEffectiveImageMaxTokens = (
+			getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+		)
+	return _cachedEffectiveImageMaxTokens
 
 
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")
@@ -2789,7 +3111,7 @@ def _buildInitialImageContents(pngBytes, prompt=None):
 		{
 			"role": "user",
 			"parts": [
-				{"text": prompt if prompt is not None else _getEffectiveImagePrompt()},
+				{"text": prompt if prompt is not None else _getRuntimeImagePrompt()},
 				{
 					"inline_data": {
 						"mime_type": "image/png",
@@ -2821,6 +3143,11 @@ def _callImageDescriptionApi(contents, timeout=None):
 			contents,
 			timeout=timeout if timeout is not None else 60.0,
 		)
+	if provider == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
+		return _callPollinationsImageDescriptionApi(
+			contents,
+			timeout=timeout if timeout is not None else 60.0,
+		)
 	return _callGoogleImageDescriptionApi(
 		contents,
 		timeout=timeout if timeout is not None else 30.0,
@@ -2845,7 +3172,10 @@ def _callGoogleImageDescriptionApi(contents, timeout=30.0):
 			model=_getEffectiveImageModel(),
 			key=apiKey,
 		)
-		body = {"contents": contents}
+		body = {
+			"contents": contents,
+			"generationConfig": {"maxOutputTokens": _getEffectiveImageMaxTokens()},
+		}
 		req = urllib.request.Request(
 			url,
 			data=json.dumps(body).encode("utf-8"),
@@ -3044,7 +3374,7 @@ def _callNvidiaImageDescriptionApi(contents, timeout=60.0):
 		body = {
 			"model": _getEffectiveNvidiaModel(),
 			"messages": messages,
-			"max_tokens": 512,
+			"max_tokens": _getEffectiveImageMaxTokens(),
 			"stream": False,
 		}
 		req = urllib.request.Request(
@@ -3098,6 +3428,126 @@ def _callNvidiaImageDescriptionApi(contents, timeout=60.0):
 	except Exception as e:
 		log.warning(
 			f"LINE: NVIDIA image description response parse failed: {e}",
+			exc_info=True,
+		)
+	return None, _("圖片描述失敗 (無回應)")
+
+
+def _geminiContentsToPollinationsMessages(contents):
+	"""Convert canonical Gemini-shaped contents into OpenAI-compatible chat messages.
+
+	Pollinations.AI's text endpoint mirrors OpenAI's /chat/completions schema, so
+	the conversion is identical to the NVIDIA NIM helper above. Kept as a
+	separate function to leave the existing NVIDIA helper untouched and to make
+	provider-specific tweaks (e.g. content/parts shape) easy in the future.
+	"""
+	messages = []
+	for turn in contents or []:
+		role = turn.get("role") if isinstance(turn, dict) else None
+		oaiRole = "assistant" if role == "model" else "user"
+		parts = []
+		for part in (turn.get("parts") or []) if isinstance(turn, dict) else []:
+			if not isinstance(part, dict):
+				continue
+			if "text" in part and part["text"]:
+				parts.append({"type": "text", "text": part["text"]})
+			elif "inline_data" in part:
+				inline = part.get("inline_data") or {}
+				data = inline.get("data")
+				mime = inline.get("mime_type") or "image/png"
+				if data:
+					parts.append(
+						{
+							"type": "image_url",
+							"image_url": {"url": f"data:{mime};base64,{data}"},
+						},
+					)
+		if not parts:
+			log.debug(f"LINE: skipping empty Pollinations turn with role {oaiRole!r}")
+			continue
+		messages.append({"role": oaiRole, "content": parts})
+	return messages
+
+
+def _callPollinationsImageDescriptionApi(contents, timeout=60.0):
+	"""Send the canonical contents to Pollinations.AI's OpenAI-compatible chat endpoint.
+
+	Returns (text, None) on success or (None, error_msg) on failure.
+	"""
+	try:
+		import json
+		import urllib.request
+		import urllib.error
+
+		apiKey = _getEffectivePollinationsApiKey()
+		messages = _geminiContentsToPollinationsMessages(contents)
+		body = {
+			"model": _getEffectivePollinationsModel(),
+			"messages": messages,
+			"max_tokens": _getEffectiveImageMaxTokens(),
+			"stream": False,
+		}
+		headers = {
+			"Content-Type": "application/json",
+			"Accept": "application/json",
+			# Pollinations.AI's edge layer rejects requests carrying urllib's
+			# default ``Python-urllib/x.y`` User-Agent with HTTP 403; matching
+			# the AI Content Describer add-on's workaround clears the block.
+			"User-Agent": "curl/8.4.0",
+		}
+		# Pollinations.AI accepts unauthenticated traffic with rate limits, but
+		# supplying the bundled token unlocks the higher tier.
+		if apiKey:
+			headers["Authorization"] = f"Bearer {apiKey}"
+		req = urllib.request.Request(
+			_IMAGE_DESCRIPTION_POLLINATIONS_ENDPOINT,
+			data=json.dumps(body).encode("utf-8"),
+			headers=headers,
+			method="POST",
+		)
+		try:
+			with urllib.request.urlopen(req, timeout=timeout) as resp:
+				raw = resp.read()
+		except urllib.error.HTTPError as e:
+			errBody = e.read().decode("utf-8", errors="replace")
+			log.warning(
+				f"LINE: Pollinations image description HTTP {e.code} {e.reason}: {errBody[:500]}",
+			)
+			return None, _("圖片描述失敗 (HTTP {code})").format(code=e.code)
+		except Exception as e:
+			log.warning(
+				f"LINE: Pollinations image description network error: {e}",
+				exc_info=True,
+			)
+			return None, _("圖片描述失敗 (網路錯誤)")
+		data = json.loads(raw.decode("utf-8", errors="replace"))
+	except Exception as e:
+		log.warning(
+			f"LINE: Pollinations image description request failed: {e}",
+			exc_info=True,
+		)
+		return None, _("圖片描述失敗")
+
+	try:
+		choices = data.get("choices") if isinstance(data, dict) else None
+		if isinstance(choices, list) and choices:
+			message = choices[0].get("message") if isinstance(choices[0], dict) else None
+			if isinstance(message, dict):
+				text = message.get("content")
+				if isinstance(text, list):
+					collected = []
+					for part in text:
+						if isinstance(part, dict):
+							inner = part.get("text")
+							if inner:
+								collected.append(inner)
+					text = "".join(collected)
+				if text:
+					return text.strip(), None
+		log.info(f"LINE: Pollinations image description returned no content: {data!r}")
+	except Exception as e:
+		log.warning(
+			f"LINE: Pollinations image description response parse failed: {e}",
 			exc_info=True,
 		)
 	return None, _("圖片描述失敗 (無回應)")
@@ -6313,6 +6763,7 @@ class AppModule(appModuleHandler.AppModule):
 		_initEffectiveImageApiKey()
 		_initEffectiveOllamaApiKey()
 		_initEffectiveNvidiaApiKey()
+		_initEffectivePollinationsApiKey()
 		log.info(
 			f"LINE AppModule loaded for process: {self.processID}, "
 			f"exe: {self.appName}, "
@@ -10510,7 +10961,7 @@ class AppModule(appModuleHandler.AppModule):
 		def _worker():
 			import wx
 
-			prompt = _getEffectiveImagePrompt()
+			prompt = _getRuntimeImagePrompt()
 			initialContents = _buildInitialImageContents(pngBytes, prompt)
 			description, errMsg = _callImageDescriptionApi(initialContents)
 			if description:

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -153,6 +153,17 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		)
 		self._promptText.SetValue(self._loadCurrentPrompt())
 
+		# Translators: Spin control label for the maximum output tokens used by the image-description AI.
+		maxTokensLabel = _("圖片描述最大 Token (&K)")
+		maxTokensRange = self._maxTokensRange()
+		self._maxTokensSpin = sHelper.addLabeledControl(
+			maxTokensLabel,
+			wx.SpinCtrl,
+			min=maxTokensRange[0],
+			max=maxTokensRange[1],
+			initial=self._loadCurrentMaxTokens(),
+		)
+
 		self._activeProviderId = self._currentSelectedProviderId() or _safeDefaultProvider()
 		self._refreshProviderUI(self._activeProviderId)
 
@@ -193,11 +204,11 @@ class LineDesktopSettingsPanel(SettingsPanel):
 
 	def _refreshProviderUI(self, provider):
 		"""Repopulate the API-key text field and the model dropdown for ``provider``."""
-		choices, defaultModel = self._modelOptionsFor(provider)
+		choices, labels, defaultModel = self._modelOptionsFor(provider)
 		self._modelChoices = choices
 		self._modelChoice.Clear()
 		if choices:
-			self._modelChoice.AppendItems(list(choices))
+			self._modelChoice.AppendItems(list(labels))
 		desiredModel = self._pendingModel.get(provider) or defaultModel
 		try:
 			selectIndex = choices.index(desiredModel)
@@ -241,15 +252,19 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			from appModules.line import (
 				_IMAGE_DESCRIPTION_PROVIDER_NVIDIA,
 				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS,
 				getUserImageApiKey,
 				getUserNvidiaApiKey,
 				getUserOllamaApiKey,
+				getUserPollinationsApiKey,
 			)
 
 			if provider == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
 				return getUserOllamaApiKey() or ""
 			if provider == _IMAGE_DESCRIPTION_PROVIDER_NVIDIA:
 				return getUserNvidiaApiKey() or ""
+			if provider == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
+				return getUserPollinationsApiKey() or ""
 			return getUserImageApiKey() or ""
 		except Exception:
 			log.debug(
@@ -264,17 +279,22 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
 				_IMAGE_DESCRIPTION_NVIDIA_DEFAULT_MODEL,
 				_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL,
 				_IMAGE_DESCRIPTION_PROVIDER_NVIDIA,
 				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS,
 				getUserImageModel,
 				getUserNvidiaModel,
 				getUserOllamaModel,
+				getUserPollinationsModel,
 			)
 
 			if provider == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
 				return getUserOllamaModel() or _IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL
 			if provider == _IMAGE_DESCRIPTION_PROVIDER_NVIDIA:
 				return getUserNvidiaModel() or _IMAGE_DESCRIPTION_NVIDIA_DEFAULT_MODEL
+			if provider == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
+				return getUserPollinationsModel() or _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL
 			return getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
 		except Exception:
 			log.debug(
@@ -284,7 +304,15 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			return ""
 
 	def _modelOptionsFor(self, provider):
-		"""Return (choices_tuple, default_model_id) for the given provider."""
+		"""Return (choices_tuple, labels_tuple, default_model_id) for the given provider.
+
+		``choices_tuple`` are model IDs that go to the API; ``labels_tuple`` are
+		the user-facing display strings shown in the dropdown. They run in
+		parallel and have the same length. Most providers use the model ID as
+		its own label; Pollinations.AI is the exception because Pollinations
+		exposes generic IDs (``openai``, ``claude-fast`` …) that aren't useful
+		without translation.
+		"""
 		try:
 			from appModules.line import (
 				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
@@ -293,27 +321,64 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				_IMAGE_DESCRIPTION_NVIDIA_DEFAULT_MODEL,
 				_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS,
 				_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS,
+				_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS,
 				_IMAGE_DESCRIPTION_PROVIDER_NVIDIA,
 				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS,
 			)
 
 			if provider == _IMAGE_DESCRIPTION_PROVIDER_OLLAMA:
 				return (
+					_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS,
 					_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS,
 					_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
 				)
 			if provider == _IMAGE_DESCRIPTION_PROVIDER_NVIDIA:
 				return (
 					_IMAGE_DESCRIPTION_NVIDIA_AVAILABLE_MODELS,
+					_IMAGE_DESCRIPTION_NVIDIA_AVAILABLE_MODELS,
 					_IMAGE_DESCRIPTION_NVIDIA_DEFAULT_MODEL,
 				)
+			if provider == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
+				ids = _IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS
+				labels = tuple(
+					_IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS.get(mid, mid) for mid in ids
+				)
+				return (ids, labels, _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL)
 			return (
+				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
 				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
 				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
 			)
 		except Exception:
 			log.debug("LINE: cannot load image model options", exc_info=True)
-			return ((), "")
+			return ((), (), "")
+
+	def _maxTokensRange(self):
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_MAX_MAX_TOKENS,
+				_IMAGE_DESCRIPTION_MIN_MAX_TOKENS,
+			)
+
+			return (_IMAGE_DESCRIPTION_MIN_MAX_TOKENS, _IMAGE_DESCRIPTION_MAX_MAX_TOKENS)
+		except Exception:
+			log.debug("LINE: cannot load max-tokens bounds", exc_info=True)
+			return (50, 4000)
+
+	def _loadCurrentMaxTokens(self):
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS,
+				getUserImageMaxTokens,
+			)
+
+			return getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+		except Exception:
+			log.debug("LINE: cannot load image max tokens", exc_info=True)
+			return 700
 
 	def _loadCurrentPrompt(self):
 		try:
@@ -375,12 +440,15 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			from appModules.line import (
 				_IMAGE_DESCRIPTION_PROVIDER_NVIDIA,
 				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS,
 				getUserImageApiKey,
 				getUserNvidiaApiKey,
 				getUserOllamaApiKey,
+				getUserPollinationsApiKey,
 				setUserImageApiKey,
 				setUserNvidiaApiKey,
 				setUserOllamaApiKey,
+				setUserPollinationsApiKey,
 			)
 
 			for providerId, pendingKey in self._pendingApiKey.items():
@@ -390,6 +458,9 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				elif providerId == _IMAGE_DESCRIPTION_PROVIDER_NVIDIA:
 					currentKey = getUserNvidiaApiKey() or ""
 					setter = setUserNvidiaApiKey
+				elif providerId == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
+					currentKey = getUserPollinationsApiKey() or ""
+					setter = setUserPollinationsApiKey
 				else:
 					currentKey = getUserImageApiKey() or ""
 					setter = setUserImageApiKey
@@ -421,14 +492,18 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				_IMAGE_DESCRIPTION_DEFAULT_MODEL,
 				_IMAGE_DESCRIPTION_NVIDIA_DEFAULT_MODEL,
 				_IMAGE_DESCRIPTION_OLLAMA_DEFAULT_MODEL,
+				_IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL,
 				_IMAGE_DESCRIPTION_PROVIDER_NVIDIA,
 				_IMAGE_DESCRIPTION_PROVIDER_OLLAMA,
+				_IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS,
 				getUserImageModel,
 				getUserNvidiaModel,
 				getUserOllamaModel,
+				getUserPollinationsModel,
 				setUserImageModel,
 				setUserNvidiaModel,
 				setUserOllamaModel,
+				setUserPollinationsModel,
 			)
 
 			for providerId, pendingModel in self._pendingModel.items():
@@ -440,6 +515,11 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				elif providerId == _IMAGE_DESCRIPTION_PROVIDER_NVIDIA:
 					currentModel = getUserNvidiaModel() or _IMAGE_DESCRIPTION_NVIDIA_DEFAULT_MODEL
 					setter = setUserNvidiaModel
+				elif providerId == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
+					currentModel = (
+						getUserPollinationsModel() or _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL
+					)
+					setter = setUserPollinationsModel
 				else:
 					currentModel = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL
 					setter = setUserImageModel
@@ -480,6 +560,31 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		except Exception:
 			log.warning(
 				"LINE: cannot load image prompt helpers from settings panel",
+				exc_info=True,
+			)
+
+		# Image description max output tokens
+		try:
+			from appModules.line import (
+				_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS,
+				getUserImageMaxTokens,
+				setUserImageMaxTokens,
+			)
+
+			newMaxTokens = int(self._maxTokensSpin.GetValue())
+			currentMaxTokens = getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+			if newMaxTokens != currentMaxTokens:
+				if not setUserImageMaxTokens(newMaxTokens):
+					gui.messageBox(
+						# Translators: Error shown when saving the image max-tokens setting fails
+						_("儲存圖片描述最大 Token 失敗，請重試。"),
+						_("LINE Desktop - 設定錯誤"),
+						wx.OK | wx.ICON_ERROR,
+						self,
+					)
+		except Exception:
+			log.warning(
+				"LINE: cannot load image max-tokens helpers from settings panel",
 				exc_info=True,
 			)
 

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -343,9 +343,7 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				)
 			if provider == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
 				ids = _IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS
-				labels = tuple(
-					_IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS.get(mid, mid) for mid in ids
-				)
+				labels = tuple(_IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS.get(mid, mid) for mid in ids)
 				return (ids, labels, _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL)
 			return (
 				_IMAGE_DESCRIPTION_AVAILABLE_MODELS,
@@ -516,9 +514,7 @@ class LineDesktopSettingsPanel(SettingsPanel):
 					currentModel = getUserNvidiaModel() or _IMAGE_DESCRIPTION_NVIDIA_DEFAULT_MODEL
 					setter = setUserNvidiaModel
 				elif providerId == _IMAGE_DESCRIPTION_PROVIDER_POLLINATIONS:
-					currentModel = (
-						getUserPollinationsModel() or _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL
-					)
+					currentModel = getUserPollinationsModel() or _IMAGE_DESCRIPTION_POLLINATIONS_DEFAULT_MODEL
 					setter = setUserPollinationsModel
 				else:
 					currentModel = getUserImageModel() or _IMAGE_DESCRIPTION_DEFAULT_MODEL


### PR DESCRIPTION
## Summary

- **Pollinations.AI provider**: New image description backend using `gen.pollinations.ai/v1/chat/completions` (OpenAI-compatible, authenticated tier). Bundled API key is encrypted with the existing PBKDF2-HMAC scheme. Four models with friendly labels: `claude-fast` → Claude Haiku 4.5, `openai` → GPT-5.4 Nano, `openai-fast` → GPT-5 Nano, `openai-large` → GPT-5.4. Requests use `User-Agent: curl/8.4.0` to avoid the 403 the Pollinations edge layer returns for Python's default UA.
- **Default prompt**: Changed from Chinese to the AI Content Describer standard English prompt. When using the default prompt, a language hint (`Respond in <Language>.`) is automatically appended based on NVDA's UI language (zh_TW/zh_HK → Chinese Traditional, zh_CN → Chinese Simplified, ja → Japanese, and 20+ other locales).
- **Max-tokens setting**: Global user-configurable max output tokens (50–4000, default 700) exposed as a SpinCtrl in the settings panel. Applied to all backends: Google (`generationConfig.maxOutputTokens`), NVIDIA, and Pollinations (`max_tokens`). NVIDIA previously had this hardcoded at 512.

## Technical notes

- Endpoint discovery: `text.pollinations.ai/openai` is the legacy API — it only exposes one text-only model and returns 404/routing errors for authenticated users requesting models like `claude-fast`. The correct authenticated endpoint is `gen.pollinations.ai/v1/chat/completions` (confirmed working with live vision test).
- All new storage files follow the existing pattern under NVDA's config dir: `line_desktop_pollinations_api_key.dat`, `line_desktop_pollinations_model.txt`, `line_desktop_image_max_tokens.txt`.
- Model dropdown for Pollinations shows user-friendly labels; internal model IDs are still sent to the API.
- `_nvdaLanguageHint()` reads NVDA's `languageHandler.getLanguage()` and maps locale codes to English language names. Language hint is only appended when the user has not customised the prompt.

## Test plan

- [x] Open Settings → LINE Desktop, verify "Pollinations.AI" appears in the provider dropdown
- [x] Select Pollinations.AI, confirm model dropdown shows Claude Haiku 4.5 / GPT-5.4 Nano / GPT-5 Nano / GPT-5.4
- [x] Verify max-tokens SpinCtrl appears (range 50–4000)
- [ ] Focus an image message in LINE and press NVDA+Windows+I with Pollinations selected
- [x] With NVDA set to zh_TW language, confirm description prompt appends "Respond in Chinese Traditional."
- [ ] Set a custom prompt and confirm the language hint is NOT added
- [ ] Confirm Google and NVIDIA still work and now respect the max-tokens setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 新增 Pollinations.AI 圖片描述後端（OpenAI 相容端點），引入全域使用者可設定的 max-tokens SpinCtrl（50–4000，預設 700），並將預設提示語從中文改為英文加上基於 NVDA UI 語言的自動語言提示（`_nvdaLanguageHint`）。

- **Pollinations.AI 後端**：新增完整的 API 金鑰管理、模型選擇（4 個視覺模型附友善標籤）、OpenAI 相容請求函式，以及 `User-Agent: curl/8.4.0` 繞過邊緣層 403 的機制。
- **全域 max-tokens**：NVIDIA 後端從硬編碼 512 改為 `_getEffectiveImageMaxTokens()`（預設 700）；Google 後端沿用 `getUserImageMaxTokens()`，僅在使用者明確設定時才送出 `maxOutputTokens`；Ollama 後端目前未套用此設定。
- **語言感知提示**：`_getRuntimeImagePrompt()` 僅對預設提示語附加 `Respond in <Language>.`，自訂提示保持不變。

<h3>Confidence Score: 5/5</h3>

所有新功能均有完善的例外處理與回退機制，滞次 PR 可安全合併。

新後端遵循現有的金鑰加密與快取模式，`_geminiContentsToPollinationsMessages` 的 OpenAI 格式轉換邏輯正確，`_nvdaLanguageHint` 對未知語言回傳 None 不會影響既有行為；唯一發現的小問題為 `_loadCurrentMaxTokens` 例外分支使用硬編碼常數，不影響執行期正確性。

無需特別關注的檔案。

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| addon/appModules/line.py | 新增 Pollinations.AI 後端、`_nvdaLanguageHint()`、`_getRuntimeImagePrompt()`，並將 Google/NVIDIA 套用全域 max-tokens 設定 |
| addon/globalPlugins/lineDesktopHelper.py | 設定面板新增 Pollinations.AI 支援與 max-tokens SpinCtrl；`_loadCurrentMaxTokens` except 分支有硬編碼 700 的細微問題 |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `addon/appModules/line.py`, line 3276-3277 ([link](https://github.com/keyang556/linedesktopnvda/blob/7d2ea13c055000d5690c0c8967704933c728c60d/addon/appModules/line.py#L3276-L3277)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Ollama 後端不套用全域最大 Token 設定**

   `_callOllamaImageDescriptionApi` 的請求 body 未包含 `max_tokens` 欄位，但其他三個後端（Google、NVIDIA、Pollinations）都已套用 `_getEffectiveImageMaxTokens()`。使用者在設定面板調整最大 Token 後切換到 Ollama，輸出長度不受控制。Ollama `/api/chat` 支援 `options.num_predict` 來限制輸出，或可在 body 最上層傳入 `num_predict`，視服務端版本而定。

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: addon/appModules/line.py
   Line: 3276-3277

   Comment:
   **Ollama 後端不套用全域最大 Token 設定**

   `_callOllamaImageDescriptionApi` 的請求 body 未包含 `max_tokens` 欄位，但其他三個後端（Google、NVIDIA、Pollinations）都已套用 `_getEffectiveImageMaxTokens()`。使用者在設定面板調整最大 Token 後切換到 Ollama，輸出長度不受控制。Ollama `/api/chat` 支援 `options.num_predict` 來限制輸出，或可在 body 最上層傳入 `num_predict`，視服務端版本而定。

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%203276-3277%0A%0AComment%3A%0A**Ollama%20%E5%BE%8C%E7%AB%AF%E4%B8%8D%E5%A5%97%E7%94%A8%E5%85%A8%E5%9F%9F%E6%9C%80%E5%A4%A7%20Token%20%E8%A8%AD%E5%AE%9A**%0A%0A%60_callOllamaImageDescriptionApi%60%20%E7%9A%84%E8%AB%8B%E6%B1%82%20body%20%E6%9C%AA%E5%8C%85%E5%90%AB%20%60max_tokens%60%20%E6%AC%84%E4%BD%8D%EF%BC%8C%E4%BD%86%E5%85%B6%E4%BB%96%E4%B8%89%E5%80%8B%E5%BE%8C%E7%AB%AF%EF%BC%88Google%E3%80%81NVIDIA%E3%80%81Pollinations%EF%BC%89%E9%83%BD%E5%B7%B2%E5%A5%97%E7%94%A8%20%60_getEffectiveImageMaxTokens%28%29%60%E3%80%82%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%E8%A8%AD%E5%AE%9A%E9%9D%A2%E6%9D%BF%E8%AA%BF%E6%95%B4%E6%9C%80%E5%A4%A7%20Token%20%E5%BE%8C%E5%88%87%E6%8F%9B%E5%88%B0%20Ollama%EF%BC%8C%E8%BC%B8%E5%87%BA%E9%95%B7%E5%BA%A6%E4%B8%8D%E5%8F%97%E6%8E%A7%E5%88%B6%E3%80%82Ollama%20%60%2Fapi%2Fchat%60%20%E6%94%AF%E6%8F%B4%20%60options.num_predict%60%20%E4%BE%86%E9%99%90%E5%88%B6%E8%BC%B8%E5%87%BA%EF%BC%8C%E6%88%96%E5%8F%AF%E5%9C%A8%20body%20%E6%9C%80%E4%B8%8A%E5%B1%A4%E5%82%B3%E5%85%A5%20%60num_predict%60%EF%BC%8C%E8%A6%96%E6%9C%8D%E5%8B%99%E7%AB%AF%E7%89%88%E6%9C%AC%E8%80%8C%E5%AE%9A%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=keyang556%2Flinedesktopnvda&pr=76&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Fawesome-goldstine-d4be88%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fawesome-goldstine-d4be88%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20addon%2FappModules%2Fline.py%0ALine%3A%203276-3277%0A%0AComment%3A%0A**Ollama%20%E5%BE%8C%E7%AB%AF%E4%B8%8D%E5%A5%97%E7%94%A8%E5%85%A8%E5%9F%9F%E6%9C%80%E5%A4%A7%20Token%20%E8%A8%AD%E5%AE%9A**%0A%0A%60_callOllamaImageDescriptionApi%60%20%E7%9A%84%E8%AB%8B%E6%B1%82%20body%20%E6%9C%AA%E5%8C%85%E5%90%AB%20%60max_tokens%60%20%E6%AC%84%E4%BD%8D%EF%BC%8C%E4%BD%86%E5%85%B6%E4%BB%96%E4%B8%89%E5%80%8B%E5%BE%8C%E7%AB%AF%EF%BC%88Google%E3%80%81NVIDIA%E3%80%81Pollinations%EF%BC%89%E9%83%BD%E5%B7%B2%E5%A5%97%E7%94%A8%20%60_getEffectiveImageMaxTokens%28%29%60%E3%80%82%E4%BD%BF%E7%94%A8%E8%80%85%E5%9C%A8%E8%A8%AD%E5%AE%9A%E9%9D%A2%E6%9D%BF%E8%AA%BF%E6%95%B4%E6%9C%80%E5%A4%A7%20Token%20%E5%BE%8C%E5%88%87%E6%8F%9B%E5%88%B0%20Ollama%EF%BC%8C%E8%BC%B8%E5%87%BA%E9%95%B7%E5%BA%A6%E4%B8%8D%E5%8F%97%E6%8E%A7%E5%88%B6%E3%80%82Ollama%20%60%2Fapi%2Fchat%60%20%E6%94%AF%E6%8F%B4%20%60options.num_predict%60%20%E4%BE%86%E9%99%90%E5%88%B6%E8%BC%B8%E5%87%BA%EF%BC%8C%E6%88%96%E5%8F%AF%E5%9C%A8%20body%20%E6%9C%80%E4%B8%8A%E5%B1%A4%E5%82%B3%E5%85%A5%20%60num_predict%60%EF%BC%8C%E8%A6%96%E6%9C%8D%E5%8B%99%E7%AB%AF%E7%89%88%E6%9C%AC%E8%80%8C%E5%AE%9A%E3%80%82%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FglobalPlugins%2FlineDesktopHelper.py%3A369-379%0A%60_loadCurrentMaxTokens%60%20%E7%9A%84%20%60except%60%20%E5%88%86%E6%94%AF%E7%9B%B4%E6%8E%A5%E5%9B%9E%E5%82%B3%E7%A1%AC%E7%B7%A8%E7%A2%BC%E7%9A%84%20%60700%60%EF%BC%8C%E8%80%8C%E9%9D%9E%E4%BD%BF%E7%94%A8%20%60_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%60%20%E5%B8%B8%E6%95%B8%E3%80%82%E8%8B%A5%E6%97%A5%E5%BE%8C%E9%A0%90%E8%A8%AD%E5%80%BC%E8%AA%BF%E6%95%B4%EF%BC%8C%E9%80%99%E5%80%8B%E4%BE%8B%E5%A4%96%E5%88%86%E6%94%AF%E7%9A%84%E5%9B%9E%E5%82%B3%E5%80%BC%E4%B8%8D%E6%9C%83%E8%B7%9F%E8%91%97%E6%9B%B4%E6%96%B0%EF%BC%8C%E5%B0%8E%E8%87%B4%E8%A8%AD%E5%AE%9A%E9%9D%A2%E6%9D%BF%E9%A1%AF%E7%A4%BA%E9%8C%AF%E8%AA%A4%E7%9A%84%E5%88%9D%E5%A7%8B%E5%80%BC%E3%80%82%0A%0A%60%60%60suggestion%0A%09def%20_loadCurrentMaxTokens%28self%29%3A%0A%09%09_defaultMaxTokens%20%3D%20700%0A%09%09try%3A%0A%09%09%09from%20appModules.line%20import%20%28%0A%09%09%09%09_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%2C%0A%09%09%09%09getUserImageMaxTokens%2C%0A%09%09%09%29%0A%0A%09%09%09_defaultMaxTokens%20%3D%20_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%0A%09%09%09return%20getUserImageMaxTokens%28%29%20or%20_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%0A%09%09except%20Exception%3A%0A%09%09%09log.debug%28%22LINE%3A%20cannot%20load%20image%20max%20tokens%22%2C%20exc_info%3DTrue%29%0A%09%09%09return%20_defaultMaxTokens%0A%60%60%60%0A%0A&repo=keyang556%2Flinedesktopnvda&pr=76&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22keyang556%2Flinedesktopnvda%22%20on%20the%20existing%20branch%20%22claude%2Fawesome-goldstine-d4be88%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fawesome-goldstine-d4be88%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aaddon%2FglobalPlugins%2FlineDesktopHelper.py%3A369-379%0A%60_loadCurrentMaxTokens%60%20%E7%9A%84%20%60except%60%20%E5%88%86%E6%94%AF%E7%9B%B4%E6%8E%A5%E5%9B%9E%E5%82%B3%E7%A1%AC%E7%B7%A8%E7%A2%BC%E7%9A%84%20%60700%60%EF%BC%8C%E8%80%8C%E9%9D%9E%E4%BD%BF%E7%94%A8%20%60_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%60%20%E5%B8%B8%E6%95%B8%E3%80%82%E8%8B%A5%E6%97%A5%E5%BE%8C%E9%A0%90%E8%A8%AD%E5%80%BC%E8%AA%BF%E6%95%B4%EF%BC%8C%E9%80%99%E5%80%8B%E4%BE%8B%E5%A4%96%E5%88%86%E6%94%AF%E7%9A%84%E5%9B%9E%E5%82%B3%E5%80%BC%E4%B8%8D%E6%9C%83%E8%B7%9F%E8%91%97%E6%9B%B4%E6%96%B0%EF%BC%8C%E5%B0%8E%E8%87%B4%E8%A8%AD%E5%AE%9A%E9%9D%A2%E6%9D%BF%E9%A1%AF%E7%A4%BA%E9%8C%AF%E8%AA%A4%E7%9A%84%E5%88%9D%E5%A7%8B%E5%80%BC%E3%80%82%0A%0A%60%60%60suggestion%0A%09def%20_loadCurrentMaxTokens%28self%29%3A%0A%09%09_defaultMaxTokens%20%3D%20700%0A%09%09try%3A%0A%09%09%09from%20appModules.line%20import%20%28%0A%09%09%09%09_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%2C%0A%09%09%09%09getUserImageMaxTokens%2C%0A%09%09%09%29%0A%0A%09%09%09_defaultMaxTokens%20%3D%20_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%0A%09%09%09return%20getUserImageMaxTokens%28%29%20or%20_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS%0A%09%09except%20Exception%3A%0A%09%09%09log.debug%28%22LINE%3A%20cannot%20load%20image%20max%20tokens%22%2C%20exc_info%3DTrue%29%0A%09%09%09return%20_defaultMaxTokens%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
addon/globalPlugins/lineDesktopHelper.py:369-379
`_loadCurrentMaxTokens` 的 `except` 分支直接回傳硬編碼的 `700`，而非使用 `_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS` 常數。若日後預設值調整，這個例外分支的回傳值不會跟著更新，導致設定面板顯示錯誤的初始值。

```suggestion
	def _loadCurrentMaxTokens(self):
		_defaultMaxTokens = 700
		try:
			from appModules.line import (
				_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS,
				getUserImageMaxTokens,
			)

			_defaultMaxTokens = _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
			return getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
		except Exception:
			log.debug("LINE: cannot load image max tokens", exc_info=True)
			return _defaultMaxTokens
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Google backend: only send maxOutputT..."](https://github.com/keyang556/linedesktopnvda/commit/d592fc6d82e4ce205cfe566dec6de5690541ecb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31429641)</sub>

<!-- /greptile_comment -->