### PR TITLE
圖片描述功能調整：Token 無限制預設、API Key 遮蔽、新增 Pollinations 模型

### DIFF
--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2082,6 +2082,16 @@ _IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS = (
 	"openai",
 	"openai-fast",
 	"openai-large",
+	"mistral",
+	"llama-scout",
+	"gemini-fast",
+	"qwen-vision",
+	"gemini-search",
+	"grok",
+	"kimi",
+	"mistral-large",
+	"qwen-large",
+	"kimi-k2.6",
 )
 # Display labels for Pollinations.AI models, surfaced in the settings dropdown.
 _IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS = {
@@ -2089,6 +2099,16 @@ _IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS = {
 	"openai": "GPT-5.4 Nano",
 	"openai-fast": "GPT-5 Nano",
 	"openai-large": "GPT-5.4",
+	"mistral": "Mistral Small 3.1",
+	"llama-scout": "Meta Llama 4 Scout 17B 16E Instruct",
+	"gemini-fast": "Gemini 2.5 Flash Lite",
+	"qwen-vision": "Qwen3 VL 30B A3B Thinking",
+	"gemini-search": "Google Gemini 2.5 Flash Lite Search",
+	"grok": "Grok 4.20 Non-Reasoning",
+	"kimi": "Moonshot Kimi K2.5",
+	"mistral-large": "Mistral Large 3",
+	"qwen-large": "Qwen3.6 Plus",
+	"kimi-k2.6": "Moonshot Kimi K2.6",
 }
 _IMAGE_DESCRIPTION_ENDPOINT = (
 	"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
@@ -2125,7 +2145,6 @@ _cachedEffectiveImageProvider = _NOT_COMPUTED
 _cachedEffectiveOllamaModel = _NOT_COMPUTED
 _cachedEffectiveNvidiaModel = _NOT_COMPUTED
 _cachedEffectivePollinationsModel = _NOT_COMPUTED
-_cachedEffectiveImageMaxTokens = _NOT_COMPUTED
 
 
 def _deriveImageApiKeyMaterial(salt, length):
@@ -2957,16 +2976,15 @@ def getUserImageMaxTokens():
 
 
 def setUserImageMaxTokens(value):
-	"""Persist a user-configured max-tokens value. None or default clears the file."""
-	global _cachedEffectiveImageMaxTokens
+	"""Persist a user-configured max-tokens value. ``None`` clears the file,
+	leaving the backend unconstrained (no ``max_tokens`` sent to the API)."""
 	path = _getImageMaxTokensStorePath()
 	if not path:
 		return False
 	try:
-		if value is None or value == _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS:
+		if value is None:
 			if os.path.isfile(path):
 				os.remove(path)
-			_cachedEffectiveImageMaxTokens = _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
 			return True
 		try:
 			n = int(value)
@@ -2978,19 +2996,10 @@ def setUserImageMaxTokens(value):
 			return False
 		with open(path, "w", encoding="utf-8") as f:
 			f.write(str(n))
-		_cachedEffectiveImageMaxTokens = n
 		return True
 	except Exception as e:
 		log.warning(f"LINE: failed to save user image max tokens: {e}", exc_info=True)
 		return False
-
-
-def _getEffectiveImageMaxTokens():
-	"""Return the cached max-tokens value; lazily resolved from disk on first call."""
-	global _cachedEffectiveImageMaxTokens
-	if _cachedEffectiveImageMaxTokens is _NOT_COMPUTED:
-		_cachedEffectiveImageMaxTokens = getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
-	return _cachedEffectiveImageMaxTokens
 
 
 _NOTES_WINDOW_KEYWORDS = ("記事本", "note", "keep", "ノート", "บันทึก", "노트")
@@ -3372,9 +3381,11 @@ def _callNvidiaImageDescriptionApi(contents, timeout=60.0):
 		body = {
 			"model": _getEffectiveNvidiaModel(),
 			"messages": messages,
-			"max_tokens": _getEffectiveImageMaxTokens(),
 			"stream": False,
 		}
+		_userMaxTokens = getUserImageMaxTokens()
+		if _userMaxTokens is not None:
+			body["max_tokens"] = _userMaxTokens
 		req = urllib.request.Request(
 			_IMAGE_DESCRIPTION_NVIDIA_ENDPOINT,
 			data=json.dumps(body).encode("utf-8"),
@@ -3482,9 +3493,11 @@ def _callPollinationsImageDescriptionApi(contents, timeout=60.0):
 		body = {
 			"model": _getEffectivePollinationsModel(),
 			"messages": messages,
-			"max_tokens": _getEffectiveImageMaxTokens(),
 			"stream": False,
 		}
+		_userMaxTokens = getUserImageMaxTokens()
+		if _userMaxTokens is not None:
+			body["max_tokens"] = _userMaxTokens
 		headers = {
 			"Content-Type": "application/json",
 			"Accept": "application/json",

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -2059,9 +2059,7 @@ _IMAGE_DESCRIPTION_AVAILABLE_MODELS = (
 )
 # Vision-capable models commonly available on Ollama Cloud. Users can pick
 # whichever they have access to; unavailable IDs surface as an HTTP error.
-_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS = (
-	"gemma4:31b-cloud",
-)
+_IMAGE_DESCRIPTION_OLLAMA_AVAILABLE_MODELS = ("gemma4:31b-cloud",)
 # Vision-capable models exposed for NVIDIA NIM. Users can pick whichever they have
 # access to; unavailable IDs surface as an HTTP error.
 _IMAGE_DESCRIPTION_NVIDIA_AVAILABLE_MODELS = (

--- a/addon/appModules/line.py
+++ b/addon/appModules/line.py
@@ -3178,9 +3178,9 @@ def _callGoogleImageDescriptionApi(contents, timeout=30.0):
 			key=apiKey,
 		)
 		body = {"contents": contents}
-		_userMaxTokens = getUserImageMaxTokens()
-		if _userMaxTokens is not None:
-			body["generationConfig"] = {"maxOutputTokens": _userMaxTokens}
+		userMaxTokens = getUserImageMaxTokens()
+		if userMaxTokens is not None:
+			body["generationConfig"] = {"maxOutputTokens": userMaxTokens}
 		req = urllib.request.Request(
 			url,
 			data=json.dumps(body).encode("utf-8"),
@@ -3381,9 +3381,9 @@ def _callNvidiaImageDescriptionApi(contents, timeout=60.0):
 			"messages": messages,
 			"stream": False,
 		}
-		_userMaxTokens = getUserImageMaxTokens()
-		if _userMaxTokens is not None:
-			body["max_tokens"] = _userMaxTokens
+		userMaxTokens = getUserImageMaxTokens()
+		if userMaxTokens is not None:
+			body["max_tokens"] = userMaxTokens
 		req = urllib.request.Request(
 			_IMAGE_DESCRIPTION_NVIDIA_ENDPOINT,
 			data=json.dumps(body).encode("utf-8"),
@@ -3493,9 +3493,9 @@ def _callPollinationsImageDescriptionApi(contents, timeout=60.0):
 			"messages": messages,
 			"stream": False,
 		}
-		_userMaxTokens = getUserImageMaxTokens()
-		if _userMaxTokens is not None:
-			body["max_tokens"] = _userMaxTokens
+		userMaxTokens = getUserImageMaxTokens()
+		if userMaxTokens is not None:
+			body["max_tokens"] = userMaxTokens
 		headers = {
 			"Content-Type": "application/json",
 			"Accept": "application/json",

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -133,7 +133,18 @@ class LineDesktopSettingsPanel(SettingsPanel):
 
 		# Translators: Text field label for the image-description API key
 		apiLabel = _("圖片描述 API Key，留空則使用預設金鑰 (&I)")
-		self._apiKeyText = sHelper.addLabeledControl(apiLabel, wx.TextCtrl)
+		# Stored under password mask by default to avoid shoulder-surfing; the
+		# "show" checkbox below recreates the control without the mask on demand.
+		self._apiKeyText = sHelper.addLabeledControl(
+			apiLabel,
+			wx.TextCtrl,
+			style=wx.TE_PASSWORD,
+		)
+		# Translators: Checkbox label for revealing the image-description API key.
+		showApiLabel = _("顯示 API 金鑰 (&S)")
+		self._showApiKeyCheck = sHelper.addItem(wx.CheckBox(self, label=showApiLabel))
+		self._showApiKeyCheck.SetValue(False)
+		self._showApiKeyCheck.Bind(wx.EVT_CHECKBOX, self._onShowApiKeyChange)
 
 		# Translators: Dropdown label for selecting the image-description model
 		modelLabel = _("圖片描述模型 (&M)")
@@ -153,6 +164,14 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		)
 		self._promptText.SetValue(self._loadCurrentPrompt())
 
+		userMaxTokens = self._loadUserMaxTokens()
+		# Translators: Checkbox label for enabling the maximum-output-tokens limit.
+		limitTokensLabel = _("限制圖片描述最大 Token (&L)")
+		self._limitTokensCheck = sHelper.addItem(
+			wx.CheckBox(self, label=limitTokensLabel),
+		)
+		self._limitTokensCheck.SetValue(userMaxTokens is not None)
+
 		# Translators: Spin control label for the maximum output tokens used by the image-description AI.
 		maxTokensLabel = _("圖片描述最大 Token (&K)")
 		maxTokensRange = self._maxTokensRange()
@@ -161,13 +180,48 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			wx.SpinCtrl,
 			min=maxTokensRange[0],
 			max=maxTokensRange[1],
-			initial=self._loadCurrentMaxTokens(),
+			initial=userMaxTokens if userMaxTokens is not None else self._defaultMaxTokens(),
 		)
+		self._maxTokensSpin.Enable(self._limitTokensCheck.GetValue())
+		self._limitTokensCheck.Bind(wx.EVT_CHECKBOX, self._onLimitTokensChange)
 
 		self._activeProviderId = self._currentSelectedProviderId() or _safeDefaultProvider()
 		self._refreshProviderUI(self._activeProviderId)
 
 		self._providerChoice.Bind(wx.EVT_CHOICE, self._onProviderChange)
+
+	def _onLimitTokensChange(self, evt):
+		self._maxTokensSpin.Enable(self._limitTokensCheck.GetValue())
+
+	def _onShowApiKeyChange(self, evt):
+		"""Recreate the API-key field so its TE_PASSWORD style can flip.
+
+		wxPython exposes no portable way to toggle ``wx.TE_PASSWORD`` on an
+		existing control, so we swap in a fresh ``wx.TextCtrl`` and let the
+		surrounding horizontal sizer re-adopt it with the same flags.
+		"""
+		if not getattr(self, "_apiKeyText", None):
+			return
+		sizer = self._apiKeyText.GetContainingSizer()
+		if sizer is None:
+			return
+		currentValue = self._apiKeyText.GetValue()
+		insertionPoint = self._apiKeyText.GetInsertionPoint()
+		hadFocus = self._apiKeyText.HasFocus()
+		showPlain = bool(self._showApiKeyCheck.GetValue())
+		style = 0 if showPlain else wx.TE_PASSWORD
+		newCtrl = wx.TextCtrl(self, style=style)
+		newCtrl.ChangeValue(currentValue)
+		try:
+			newCtrl.SetInsertionPoint(insertionPoint)
+		except Exception:
+			pass
+		sizer.Replace(self._apiKeyText, newCtrl)
+		self._apiKeyText.Destroy()
+		self._apiKeyText = newCtrl
+		self.Layout()
+		if hadFocus:
+			newCtrl.SetFocus()
 
 	def _currentSelectedProviderId(self):
 		"""Return the provider ID matching the dropdown selection, or None."""
@@ -366,16 +420,24 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			log.debug("LINE: cannot load max-tokens bounds", exc_info=True)
 			return (50, 4000)
 
-	def _loadCurrentMaxTokens(self):
+	def _loadUserMaxTokens(self):
+		"""Return the user-configured max tokens, or ``None`` when unset (= no limit)."""
 		try:
-			from appModules.line import (
-				_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS,
-				getUserImageMaxTokens,
-			)
+			from appModules.line import getUserImageMaxTokens
 
-			return getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+			return getUserImageMaxTokens()
 		except Exception:
 			log.debug("LINE: cannot load image max tokens", exc_info=True)
+			return None
+
+	def _defaultMaxTokens(self):
+		"""Return the suggested spin-control initial value when the user enables the limit."""
+		try:
+			from appModules.line import _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+
+			return _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+		except Exception:
+			log.debug("LINE: cannot load default image max tokens", exc_info=True)
 			return 700
 
 	def _loadCurrentPrompt(self):
@@ -559,16 +621,18 @@ class LineDesktopSettingsPanel(SettingsPanel):
 				exc_info=True,
 			)
 
-		# Image description max output tokens
+		# Image description max output tokens: ``None`` means no limit (file cleared).
 		try:
 			from appModules.line import (
-				_IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS,
 				getUserImageMaxTokens,
 				setUserImageMaxTokens,
 			)
 
-			newMaxTokens = int(self._maxTokensSpin.GetValue())
-			currentMaxTokens = getUserImageMaxTokens() or _IMAGE_DESCRIPTION_DEFAULT_MAX_TOKENS
+			if self._limitTokensCheck.GetValue():
+				newMaxTokens = int(self._maxTokensSpin.GetValue())
+			else:
+				newMaxTokens = None
+			currentMaxTokens = getUserImageMaxTokens()
 			if newMaxTokens != currentMaxTokens:
 				if not setUserImageMaxTokens(newMaxTokens):
 					gui.messageBox(

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -216,7 +216,10 @@ class LineDesktopSettingsPanel(SettingsPanel):
 			newCtrl.SetInsertionPoint(insertionPoint)
 		except Exception:
 			pass
-		sizer.Replace(self._apiKeyText, newCtrl)
+		if not sizer.Replace(self._apiKeyText, newCtrl):
+			log.warning("LINE: sizer.Replace failed when toggling API-key visibility")
+			newCtrl.Destroy()
+			return
 		self._apiKeyText.Destroy()
 		self._apiKeyText = newCtrl
 		self.Layout()

--- a/addon/globalPlugins/lineDesktopHelper.py
+++ b/addon/globalPlugins/lineDesktopHelper.py
@@ -133,8 +133,8 @@ class LineDesktopSettingsPanel(SettingsPanel):
 
 		# Translators: Text field label for the image-description API key
 		apiLabel = _("圖片描述 API Key，留空則使用預設金鑰 (&I)")
-		# Stored under password mask by default to avoid shoulder-surfing; the
-		# "show" checkbox below recreates the control without the mask on demand.
+		# wx.TE_PASSWORD creates a Win32 Edit with ES_PASSWORD; the "show"
+		# checkbox below sends EM_SETPASSWORDCHAR to toggle masking in place.
 		self._apiKeyText = sHelper.addLabeledControl(
 			apiLabel,
 			wx.TextCtrl,
@@ -194,37 +194,19 @@ class LineDesktopSettingsPanel(SettingsPanel):
 		self._maxTokensSpin.Enable(self._limitTokensCheck.GetValue())
 
 	def _onShowApiKeyChange(self, evt):
-		"""Recreate the API-key field so its TE_PASSWORD style can flip.
+		"""Toggle password masking on the API-key field in place.
 
-		wxPython exposes no portable way to toggle ``wx.TE_PASSWORD`` on an
-		existing control, so we swap in a fresh ``wx.TextCtrl`` and let the
-		surrounding horizontal sizer re-adopt it with the same flags.
+		Uses the Win32 ``EM_SETPASSWORDCHAR`` message so the TextCtrl never
+		moves or loses its label — no sizer manipulation required.
 		"""
 		if not getattr(self, "_apiKeyText", None):
 			return
-		sizer = self._apiKeyText.GetContainingSizer()
-		if sizer is None:
-			return
-		currentValue = self._apiKeyText.GetValue()
-		insertionPoint = self._apiKeyText.GetInsertionPoint()
-		hadFocus = self._apiKeyText.HasFocus()
 		showPlain = bool(self._showApiKeyCheck.GetValue())
-		style = 0 if showPlain else wx.TE_PASSWORD
-		newCtrl = wx.TextCtrl(self, style=style)
-		newCtrl.ChangeValue(currentValue)
-		try:
-			newCtrl.SetInsertionPoint(insertionPoint)
-		except Exception:
-			pass
-		if not sizer.Replace(self._apiKeyText, newCtrl):
-			log.warning("LINE: sizer.Replace failed when toggling API-key visibility")
-			newCtrl.Destroy()
-			return
-		self._apiKeyText.Destroy()
-		self._apiKeyText = newCtrl
-		self.Layout()
-		if hadFocus:
-			newCtrl.SetFocus()
+		_EM_SETPASSWORDCHAR = 0x00CC
+		hwnd = self._apiKeyText.GetHandle()
+		# wParam 0 = show plain text; ord('*') = mask with asterisks
+		ctypes.windll.user32.SendMessageW(hwnd, _EM_SETPASSWORDCHAR, 0 if showPlain else ord("*"), 0)
+		self._apiKeyText.Refresh()
 
 	def _currentSelectedProviderId(self):
 		"""Return the provider ID matching the dropdown selection, or None."""


### PR DESCRIPTION
## Summary

- **Token 限制改為預設無限制**：新增「限制圖片描述最大 Token (&L)」checkbox。預設不勾選時，三個 backend（Google / NVIDIA / Pollinations）皆不向 API 傳送 `max_tokens`/`maxOutputTokens` 參數，讓模型自由輸出。勾選後 SpinCtrl 啟用可自行調整數值。同步移除已無用的 `_getEffectiveImageMaxTokens` 快取函式與相關 `_cachedEffectiveImageMaxTokens` 全域變數。

- **API Key 欄位改為密碼模式**：`wx.TextCtrl` 預設加上 `wx.TE_PASSWORD` 樣式遮蔽內容，避免旁人窺視。旁邊新增「顯示 API 金鑰 (&S)」checkbox，勾選後透過 `sizer.Replace()` 將控制項換成不帶遮罩的新 `wx.TextCtrl`（wxPython 無法熱切換 TE_PASSWORD 旗標），並保留游標位置與焦點。

- **Pollinations.AI 新增 10 個模型**：
  | 顯示名稱 | API 端點 |
  |---|---|
  | Mistral Small 3.1 | `mistral` |
  | Meta Llama 4 Scout 17B 16E Instruct | `llama-scout` |
  | Gemini 2.5 Flash Lite | `gemini-fast` |
  | Qwen3 VL 30B A3B Thinking | `qwen-vision` |
  | Google Gemini 2.5 Flash Lite Search | `gemini-search` |
  | Grok 4.20 Non-Reasoning | `grok` |
  | Moonshot Kimi K2.5 | `kimi` |
  | Mistral Large 3 | `mistral-large` |
  | Qwen3.6 Plus | `qwen-large` |
  | Moonshot Kimi K2.6 | `kimi-k2.6` |

## Test plan

- [x] 開啟 NVDA 設定 → LINE Desktop，確認 API Key 欄位預設顯示遮蔽字元
- [x] 勾選「顯示 API 金鑰」後確認明文出現，再取消勾選確認重新遮蔽，且值不遺失
- [x] 確認「限制圖片描述最大 Token」預設未勾選，SpinCtrl 為停用狀態
- [ ] 勾選 Token 限制後調整數值，儲存後重開設定確認值保留
- [x] 取消勾選 Token 限制後儲存，確認不帶 max_tokens 送出（可用抓包或 log 確認）
- [x] 切換至 Pollinations.AI 服務，確認模型下拉選單包含新增的 10 個模型
- [x] 執行 `pytest` 確認全部測試通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

此 PR 在圖片描述功能上做了三項獨立調整：Token 上限預設改為無限制（需勾選 checkbox 才啟用）、API Key 欄位預設遮蔽並以 Win32 `EM_SETPASSWORDCHAR` 實作顯示切換、以及新增 10 個 Pollinations.AI 模型。

- **Token 無限制**：移除 `_getEffectiveImageMaxTokens` 快取函式與 `_cachedEffectiveImageMaxTokens` 全域變數，改由各後端直接呼叫 `getUserImageMaxTokens()` 並在回傳 `None` 時省略 `max_tokens` 參數；UI 端以 checkbox 控制是否傳送限制值，邏輯一致。
- **API Key 遮蔽**：以 `ctypes.windll.user32.SendMessageW` 傳送 `EM_SETPASSWORDCHAR` 訊息切換遮蔽狀態，避免 sizer 重排；`ctypes` 已在檔案頂部 import，Win32 常數值正確（`0x00CC`）。
- **Pollinations 模型**：10 個新模型同步加入 `_IMAGE_DESCRIPTION_POLLINATIONS_AVAILABLE_MODELS` tuple 與 `_IMAGE_DESCRIPTION_POLLINATIONS_MODEL_LABELS` dict，且下拉選單的 label 產生邏輯（`.get(mid, mid)`）能正確 fallback，無遺漏。

<h3>Confidence Score: 5/5</h3>

此 PR 三項改動邏輯均正確且一致，無資料遺失或邊界條件問題，可安全合併。

Token 限制的 checkbox 邏輯、None 判斷與 setUserImageMaxTokens 的行為完全匹配；EM_SETPASSWORDCHAR 透過 ctypes 切換遮蔽狀態的實作方式在 Windows 上正確可靠；新增的 10 個 Pollinations 模型已同步更新 tuple 與 labels dict，下拉選單 fallback 邏輯也能處理潛在缺漏。整體變更範圍明確，未破壞既有功能。

兩個檔案均無需特別關注。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| addon/globalPlugins/lineDesktopHelper.py | 新增 API Key 遮蔽切換（EM_SETPASSWORDCHAR via ctypes）、Token 限制 checkbox 及對應事件處理邏輯；實作正確，ctypes 已 import，無邏輯錯誤。 |
| addon/appModules/line.py | 移除 _getEffectiveImageMaxTokens 快取函式及相關全域變數；三個後端改為直接讀取 getUserImageMaxTokens() 並條件性加入 max_tokens；新增 10 個 Pollinations 模型至 tuple 與 labels dict，均一致無遺漏。 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[使用者開啟設定面板] --> B[API Key TextCtrl\nwx.TE_PASSWORD 建立]
    B --> C{勾選「顯示 API 金鑰」?}
    C -- 是 --> D[SendMessageW\nEM_SETPASSWORDCHAR wParam=0\n顯示明文]
    C -- 否 --> E[SendMessageW\nEM_SETPASSWORDCHAR wParam=ord★\n遮蔽顯示]
    D --> F[Refresh 重繪]
    E --> F

    G[使用者開啟設定面板] --> H{勾選「限制最大 Token」?}
    H -- 是 --> I[SpinCtrl 啟用\n讀取 getUserImageMaxTokens]
    H -- 否 --> J[SpinCtrl 停用\nnewMaxTokens = None]

    K[onSave] --> L{_limitTokensCheck?}
    L -- 勾選 --> M[newMaxTokens = SpinCtrl.GetValue\nsetUserImageMaxTokens n]
    L -- 未勾選 --> N[setUserImageMaxTokens None\n清除 max_tokens 檔案]

    O[API 呼叫] --> P[getUserImageMaxTokens]
    P --> Q{回傳值?}
    Q -- None --> R[不傳送 max_tokens\n讓模型自由輸出]
    Q -- 整數 --> S[加入 max_tokens / maxOutputTokens\n至 request body]
```

<sub>Reviews (3): Last reviewed commit: ["Fix API key show/hide: use EM\_SETPASSWOR..."](https://github.com/keyang556/linedesktopnvda/commit/7774ca1f0804a357f60c2f0ad528ffabb988ed59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32094426)</sub>

<!-- /greptile_comment -->